### PR TITLE
Add implementation and test to improve this mechanism.

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -28,17 +28,21 @@ class HTTPRequest final : public IURLRequest, public Singleton<HTTPRequest>
         void post(const URL &url,
                   const nlohmann::json &data,
                   std::function<void(const std::string &)> onSuccess,
-                  std::function<void(const std::string &)> onError = [](auto){});
+                  std::function<void(const std::string &)> onError = [](auto){},
+                  const std::string &fileName = "");
         void get(const URL &url,
                  std::function<void(const std::string &)> onSuccess,
-                 std::function<void(const std::string &)> onError = [](auto){});
+                 std::function<void(const std::string &)> onError = [](auto){},
+                 const std::string &fileName = "");
         void update(const URL &url,
                     const nlohmann::json &data,
                     std::function<void(const std::string &)> onSuccess,
-                    std::function<void(const std::string &)> onError = [](auto){});
+                    std::function<void(const std::string &)> onError = [](auto){},
+                    const std::string &fileName = "");
         void delete_(const URL &url,
                      std::function<void(const std::string &)> onSuccess,
-                     std::function<void(const std::string &)> onError = [](auto){});
+                     std::function<void(const std::string &)> onError = [](auto){},
+                     const std::string &fileName = "");
 };
 
 #endif // _HTTP_REQUEST_HPP

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -68,20 +68,24 @@ class IURLRequest
         virtual void post(const URL &url,
                           const nlohmann::json &data,
                           std::function<void(const std::string &)> onSuccess,
-                          std::function<void(const std::string &)> onError = [](auto){}) = 0;
+                          std::function<void(const std::string &)> onError = [](auto){},
+                          const std::string &fileName = "") = 0;
 
         virtual void get(const URL &url,
                          std::function<void(const std::string &)> onSuccess,
-                         std::function<void(const std::string &)> onError = [](auto){}) = 0;
+                         std::function<void(const std::string &)> onError = [](auto){},
+                         const std::string &fileName = "") = 0;
 
         virtual void update(const URL &url,
                             const nlohmann::json &data,
                             std::function<void(const std::string &)> onSuccess,
-                            std::function<void(const std::string &)> onError = [](auto){}) = 0;
+                            std::function<void(const std::string &)> onError = [](auto){},
+                            const std::string &fileName = "") = 0;
 
         virtual void delete_(const URL &url,
-                            std::function<void(const std::string &)> onSuccess,
-                            std::function<void(const std::string &)> onError = [](auto){}) = 0;
+                             std::function<void(const std::string &)> onSuccess,
+                             std::function<void(const std::string &)> onError = [](auto){},
+                             const std::string &fileName = "") = 0;
 };
 
 #endif // _URL_REQUEST_HPP

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -28,17 +28,21 @@ class UNIXSocketRequest final : public IURLRequest, public Singleton<UNIXSocketR
         void post(const URL &url,
                   const nlohmann::json &data,
                   std::function<void(const std::string &)> onSuccess,
-                  std::function<void(const std::string &)> onError = [](auto){});
+                  std::function<void(const std::string &)> onError = [](auto){},
+                  const std::string &fileName = "");
         void get(const URL &url,
                  std::function<void(const std::string &)> onSuccess,
-                 std::function<void(const std::string &)> onError = [](auto){});
+                 std::function<void(const std::string &)> onError = [](auto){},
+                 const std::string &fileName = "");
         void update(const URL &url,
                     const nlohmann::json &data,
                     std::function<void(const std::string &)> onSuccess,
-                    std::function<void(const std::string &)> onError = [](auto){});
+                    std::function<void(const std::string &)> onError = [](auto){},
+                    const std::string &fileName = "");
         void delete_(const URL &url,
                      std::function<void(const std::string &)> onSuccess,
-                     std::function<void(const std::string &)> onError = [](auto){});
+                     std::function<void(const std::string &)> onError = [](auto){},
+                     const std::string &fileName = "");
 };
 
 #endif // _UNIX_SOCKET_REQUEST_HPP

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -36,7 +36,8 @@ void HTTPRequest::download(const URL &url,
 void HTTPRequest::post(const URL &url,
                        const nlohmann::json &data,
                        std::function<void(const std::string &)> onSuccess,
-                       std::function<void(const std::string &)> onError)
+                       std::function<void(const std::string &)> onError,
+                       const std::string &fileName)
 {
     try
     {
@@ -46,6 +47,7 @@ void HTTPRequest::post(const URL &url,
             .appendHeader("Content-Type: application/json")
             .appendHeader("Accept: application/json")
             .appendHeader("Accept-Charset: utf-8")
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());
@@ -58,7 +60,8 @@ void HTTPRequest::post(const URL &url,
 
 void HTTPRequest::get(const URL &url,
                       std::function<void(const std::string &)> onSuccess,
-                      std::function<void(const std::string &)> onError)
+                      std::function<void(const std::string &)> onError,
+                      const std::string &fileName)
 {
     try
     {
@@ -67,6 +70,7 @@ void HTTPRequest::get(const URL &url,
             .appendHeader("Content-Type: application/json")
             .appendHeader("Accept: application/json")
             .appendHeader("Accept-Charset: utf-8")
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());
@@ -80,7 +84,8 @@ void HTTPRequest::get(const URL &url,
 void HTTPRequest::update(const URL &url,
                          const nlohmann::json &data,
                          std::function<void(const std::string &)> onSuccess,
-                         std::function<void(const std::string &)> onError)
+                         std::function<void(const std::string &)> onError,
+                         const std::string &fileName)
 {
     try
     {
@@ -90,6 +95,7 @@ void HTTPRequest::update(const URL &url,
             .appendHeader("Content-Type: application/json")
             .appendHeader("Accept: application/json")
             .appendHeader("Accept-Charset: utf-8")
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());
@@ -102,7 +108,8 @@ void HTTPRequest::update(const URL &url,
 
 void HTTPRequest::delete_(const URL &url,
                           std::function<void(const std::string &)> onSuccess,
-                          std::function<void(const std::string &)> onError)
+                          std::function<void(const std::string &)> onError,
+                          const std::string &fileName)
 {
     try
     {
@@ -111,6 +118,7 @@ void HTTPRequest::delete_(const URL &url,
             .appendHeader("Content-Type: application/json")
             .appendHeader("Accept: application/json")
             .appendHeader("Accept-Charset: utf-8")
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -36,7 +36,8 @@ void UNIXSocketRequest::download(const URL &url,
 void UNIXSocketRequest::post(const URL &url,
                              const nlohmann::json &data,
                              std::function<void(const std::string &)> onSuccess,
-                             std::function<void(const std::string &)> onError)
+                             std::function<void(const std::string &)> onError,
+                             const std::string &fileName)
 {
     try
     {
@@ -44,6 +45,7 @@ void UNIXSocketRequest::post(const URL &url,
         req.url(url.url())
             .unixSocketPath(url.unixSocketPath())
             .postData(data)
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());
@@ -56,13 +58,15 @@ void UNIXSocketRequest::post(const URL &url,
 
 void UNIXSocketRequest::get(const URL &url,
                             std::function<void(const std::string &)> onSuccess,
-                            std::function<void(const std::string &)> onError)
+                            std::function<void(const std::string &)> onError,
+                            const std::string &fileName)
 {
     try
     {
         auto req { GetRequest::builder(FactoryRequestWrapper<wrapperType>::create()) };
         req.url(url.url())
             .unixSocketPath(url.unixSocketPath())
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());
@@ -76,7 +80,8 @@ void UNIXSocketRequest::get(const URL &url,
 void UNIXSocketRequest::update(const URL &url,
                                const nlohmann::json &data,
                                std::function<void(const std::string &)> onSuccess,
-                               std::function<void(const std::string &)> onError)
+                               std::function<void(const std::string &)> onError,
+                               const std::string &fileName)
 {
     try
     {
@@ -84,6 +89,7 @@ void UNIXSocketRequest::update(const URL &url,
         req.url(url.url())
             .unixSocketPath(url.unixSocketPath())
             .postData(data)
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());
@@ -96,13 +102,15 @@ void UNIXSocketRequest::update(const URL &url,
 
 void UNIXSocketRequest::delete_(const URL &url,
                                 std::function<void(const std::string &)> onSuccess,
-                                std::function<void(const std::string &)> onError)
+                                std::function<void(const std::string &)> onError,
+                                const std::string &fileName)
 {
     try
     {
         auto req { DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create()) };
         req.url(url.url())
             .unixSocketPath(url.unixSocketPath())
+            .outputFile(fileName)
             .execute();
 
         onSuccess(req.response());

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -50,7 +50,8 @@ EchoServer server;
 TEST_F(ComponentTestInterface, GetHelloWorld)
 {
     auto callbackComplete = false;
-    HTTPRequest::instance().get(HttpURL("http://localhost:44441/"), [&](const std::string &result)
+    HTTPRequest::instance().get(HttpURL("http://localhost:44441/"),
+                                [&](const std::string &result)
     {
         EXPECT_EQ(result, "Hello World!");
         callbackComplete = true;
@@ -62,7 +63,9 @@ TEST_F(ComponentTestInterface, GetHelloWorld)
 TEST_F(ComponentTestInterface, PostHelloWorld)
 {
     auto callbackComplete = false;
-    HTTPRequest::instance().post(HttpURL("http://localhost:44441/"), R"({"hello":"world"})"_json, [&](const std::string &result)
+    HTTPRequest::instance().post(HttpURL("http://localhost:44441/"),
+                                 R"({"hello":"world"})"_json,
+                                 [&](const std::string &result)
     {
         EXPECT_EQ(result, R"({"hello":"world"})");
         callbackComplete = true;
@@ -74,7 +77,9 @@ TEST_F(ComponentTestInterface, PostHelloWorld)
 TEST_F(ComponentTestInterface, PutHelloWorld)
 {
     auto callbackComplete = false;
-    HTTPRequest::instance().update(HttpURL("http://localhost:44441/"), R"({"hello":"world"})"_json, [&](const std::string &result)
+    HTTPRequest::instance().update(HttpURL("http://localhost:44441/"),
+                                   R"({"hello":"world"})"_json,
+                                   [&](const std::string &result)
     {
         EXPECT_EQ(result, R"({"hello":"world"})");
         callbackComplete = true;
@@ -88,7 +93,8 @@ TEST_F(ComponentTestInterface, DeleteRandomID)
     auto random { std::to_string(std::rand()) };
 
     auto callbackComplete = false;
-    HTTPRequest::instance().delete_(HttpURL("http://localhost:44441/"+random), [&](const std::string &result)
+    HTTPRequest::instance().delete_(HttpURL("http://localhost:44441/"+random),
+                                    [&](const std::string &result)
     {
         EXPECT_EQ(result, random);
         callbackComplete = true;
@@ -99,7 +105,9 @@ TEST_F(ComponentTestInterface, DeleteRandomID)
 
 TEST_F(ComponentTestInterface, DownloadFile)
 {
-    HTTPRequest::instance().download(HttpURL("http://localhost:44441/"), "./test.txt", [&](const std::string &result)
+    HTTPRequest::instance().download(HttpURL("http://localhost:44441/"),
+                                     "./test.txt",
+                                     [&](const std::string &result)
     {
         std::cout << result << std::endl;
     });
@@ -113,7 +121,9 @@ TEST_F(ComponentTestInterface, DownloadFile)
 TEST_F(ComponentTestInterface, DownloadFileError)
 {
     auto callbackComplete = false;
-    HTTPRequest::instance().download(HttpURL("http://localhost:44441/invalid_file"), "./test.txt", [&](const std::string &result)
+    HTTPRequest::instance().download(HttpURL("http://localhost:44441/invalid_file"),
+                                     "./test.txt",
+                                     [&](const std::string &result)
     {
         EXPECT_EQ(result, "HTTP response code said error");
         callbackComplete = true;
@@ -122,25 +132,67 @@ TEST_F(ComponentTestInterface, DownloadFileError)
     EXPECT_TRUE(callbackComplete);
 }
 
-using wrapperType = cURLWrapper;
-
-TEST_F(ComponentTestInternalParameters, DownloadFileErrorEmptyOutput)
+TEST_F(ComponentTestInterface, GetHelloWorldFile)
 {
-    auto callbackComplete = false;
-    try
+    HTTPRequest::instance().get(HttpURL("http://localhost:44441/"),
+                                [&](const std::string &result)
     {
-        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
-            .url("wazuh.com")
-            .outputFile("")
-            .execute();
-    }
-    catch (const std::exception &ex)
-    {
-        EXPECT_EQ(std::string(ex.what()), "Failed to open output file");
-        callbackComplete = true;
-    }
-    EXPECT_TRUE(callbackComplete);
+        std::cout << result << std::endl;
+    }, [](auto){}, "./testGetHelloWorld.txt");
+
+    std::ifstream file("./testGetHelloWorld.txt");
+    std::string line;
+    std::getline(file, line);
+    EXPECT_EQ(line, "Hello World!");
 }
+
+TEST_F(ComponentTestInterface, PostHelloWorldFile)
+{
+    HTTPRequest::instance().post(HttpURL("http://localhost:44441/"),
+                                 R"({"hello":"world"})"_json,
+                                 [&](const std::string &result)
+    {
+        std::cout << result << std::endl;
+    }, [](auto){}, "./testPostHelloWorld.txt");
+
+    std::ifstream file("./testPostHelloWorld.txt");
+    std::string line;
+    std::getline(file, line);
+    EXPECT_EQ(line, R"({"hello":"world"})");
+}
+
+TEST_F(ComponentTestInterface, PutHelloWorldFile)
+{
+    HTTPRequest::instance().update(HttpURL("http://localhost:44441/"),
+                                   R"({"hello":"world"})"_json,
+                                   [&](const std::string &result)
+    {
+        std::cout << result << std::endl;
+    }, [](auto){}, "./testPutHelloWorld.txt");
+
+    std::ifstream file("./testPutHelloWorld.txt");
+    std::string line;
+    std::getline(file, line);
+    EXPECT_EQ(line, R"({"hello":"world"})");
+}
+
+TEST_F(ComponentTestInterface, DeleteRandomIDFile)
+{
+    auto random { std::to_string(std::rand()) };
+
+    HTTPRequest::instance().delete_(HttpURL("http://localhost:44441/"+random),
+                                    [&](const std::string &result)
+    {
+        std::cout << result << std::endl;
+    }, [](auto){}, "./testDeleteRandomID.txt");
+
+    std::ifstream file("./testDeleteRandomID.txt");
+    std::string line;
+    std::getline(file, line);
+    EXPECT_EQ(line, random);
+}
+
+using wrapperType = cURLWrapper;
 
 TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl)
 {

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -49,58 +49,54 @@ EchoServer server;
 
 TEST_F(ComponentTestInterface, GetHelloWorld)
 {
-    auto callbackComplete = false;
     HTTPRequest::instance().get(HttpURL("http://localhost:44441/"),
                                 [&](const std::string &result)
     {
         EXPECT_EQ(result, "Hello World!");
-        callbackComplete = true;
+        m_callbackComplete = true;
     });
 
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInterface, PostHelloWorld)
 {
-    auto callbackComplete = false;
     HTTPRequest::instance().post(HttpURL("http://localhost:44441/"),
                                  R"({"hello":"world"})"_json,
                                  [&](const std::string &result)
     {
         EXPECT_EQ(result, R"({"hello":"world"})");
-        callbackComplete = true;
+        m_callbackComplete = true;
     });
 
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInterface, PutHelloWorld)
 {
-    auto callbackComplete = false;
     HTTPRequest::instance().update(HttpURL("http://localhost:44441/"),
                                    R"({"hello":"world"})"_json,
                                    [&](const std::string &result)
     {
         EXPECT_EQ(result, R"({"hello":"world"})");
-        callbackComplete = true;
+        m_callbackComplete = true;
     });
 
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInterface, DeleteRandomID)
 {
     auto random { std::to_string(std::rand()) };
 
-    auto callbackComplete = false;
     HTTPRequest::instance().delete_(HttpURL("http://localhost:44441/"+random),
                                     [&](const std::string &result)
     {
         EXPECT_EQ(result, random);
-        callbackComplete = true;
+        m_callbackComplete = true;
     });
 
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInterface, DownloadFile)
@@ -120,16 +116,15 @@ TEST_F(ComponentTestInterface, DownloadFile)
 
 TEST_F(ComponentTestInterface, DownloadFileError)
 {
-    auto callbackComplete = false;
     HTTPRequest::instance().download(HttpURL("http://localhost:44441/invalid_file"),
                                      "./test.txt",
                                      [&](const std::string &result)
     {
         EXPECT_EQ(result, "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     });
 
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInterface, GetHelloWorldFile)
@@ -196,7 +191,6 @@ using wrapperType = cURLWrapper;
 
 TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl)
 {
-    auto callbackComplete = false;
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -207,14 +201,13 @@ TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "URL using bad/illegal format or missing URL");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl2)
 {
-    auto callbackComplete = false;
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -225,14 +218,13 @@ TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl2)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "URL using bad/illegal format or missing URL");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, GetError)
 {
-    auto callbackComplete = false;
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -242,14 +234,13 @@ TEST_F(ComponentTestInternalParameters, GetError)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, PostError)
 {
-    auto callbackComplete = false;
     try
     {
         PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -260,14 +251,13 @@ TEST_F(ComponentTestInternalParameters, PostError)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, PutError)
 {
-    auto callbackComplete = false;
     try
     {
         PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -278,14 +268,13 @@ TEST_F(ComponentTestInternalParameters, PutError)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, DeleteError)
 {
-    auto callbackComplete = false;
     try
     {
         DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -295,14 +284,13 @@ TEST_F(ComponentTestInternalParameters, DeleteError)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, ExecuteGetNoUrl)
 {
-    auto callbackComplete = false;
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -311,14 +299,13 @@ TEST_F(ComponentTestInternalParameters, ExecuteGetNoUrl)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, ExecutePostNoUrl)
 {
-    auto callbackComplete = false;
     try
     {
         PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -327,14 +314,13 @@ TEST_F(ComponentTestInternalParameters, ExecutePostNoUrl)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, ExecutePutNoUrl)
 {
-    auto callbackComplete = false;
     try
     {
         PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -343,14 +329,13 @@ TEST_F(ComponentTestInternalParameters, ExecutePutNoUrl)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 
 TEST_F(ComponentTestInternalParameters, ExecuteDeleteNoUrl)
 {
-    auto callbackComplete = false;
     try
     {
         DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -359,8 +344,8 @@ TEST_F(ComponentTestInternalParameters, ExecuteDeleteNoUrl)
     catch (const std::exception &ex)
     {
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
-        callbackComplete = true;
+        m_callbackComplete = true;
     }
-    EXPECT_TRUE(callbackComplete);
+    EXPECT_TRUE(m_callbackComplete);
 }
 

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -23,18 +23,24 @@
 
 #include "HTTPRequest.hpp"
 
-class ComponentTestInterface : public ::testing::Test
+class ComponentTest : public ::testing::Test
 {
     protected:
+        bool m_callbackComplete;
+        virtual ~ComponentTest() = default;
+        void SetUp() override { m_callbackComplete = false; }
+};
 
+class ComponentTestInterface : public ComponentTest
+{
+    protected:
         ComponentTestInterface() = default;
         virtual ~ComponentTestInterface() = default;
 };
 
-class ComponentTestInternalParameters : public ::testing::Test
+class ComponentTestInternalParameters : public ComponentTest
 {
     protected:
-
         ComponentTestInternalParameters() = default;
         virtual ~ComponentTestInternalParameters() = default;
 };


### PR DESCRIPTION
## Description
This PR improve the interfaces, to accept a filepath to download a file in the API response.

For this change, the derived output mechanism is generalized in a file, this means that it is no longer specific for the get itself.