### PR TITLE
Fix invalid initialization of cURL. This must be done in each call.

### DIFF
--- a/src/curlWrapper.hpp
+++ b/src/curlWrapper.hpp
@@ -21,7 +21,6 @@
 #include <stdexcept>
 
 using deleterCurl = CustomDeleter<decltype(&curl_easy_cleanup), curl_easy_cleanup>;
-static const std::unique_ptr<CURL, deleterCurl> m_curlHandle {curl_easy_init()};
 
 static const std::map<OPTION_REQUEST_TYPE, CURLoption> OPTION_REQUEST_TYPE_MAP = {
     {OPT_URL, CURLOPT_URL},
@@ -50,8 +49,11 @@ private:
     }
     std::string m_returnValue;
 
+    const std::unique_ptr<CURL, deleterCurl> m_curlHandle;
+
 public:
     cURLWrapper()
+        : m_curlHandle {curl_easy_init()}
     {
         if (!m_curlHandle)
         {

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -16,7 +16,6 @@
 
 #include "HTTPRequest.hpp"
 #include "benchmark.h"
-#include "curlWrapper.hpp"
 #include <iostream>
 
 class FakeServer final

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -19,39 +19,51 @@
 #include "curlWrapper.hpp"
 #include <iostream>
 
-class EchoServer
+class FakeServer final
 {
+private:
+    httplib::Server m_server;
+    std::thread m_thread;
+
 public:
-    EchoServer()
+    FakeServer()
+        : m_thread(&FakeServer::run, this)
     {
-        std::thread t(
-            [&]()
-            {
-                httplib::Server server;
+        // Wait until server is ready
+        while (!m_server.is_running())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
 
-                server.Get("/",
-                           [](const httplib::Request& /*req*/, httplib::Response& res)
-                           { res.set_content("Hello World!", "text/json"); });
+    ~FakeServer()
+    {
+        m_server.stop();
+        m_thread.join();
+    }
 
-                server.Post("/",
-                            [](const httplib::Request& req, httplib::Response& res)
-                            { res.set_content(req.body, "text/json"); });
+    void run()
+    {
+        m_server.Get("/",
+                     [](const httplib::Request& /*req*/, httplib::Response& res)
+                     { res.set_content("Hello World!", "text/json"); });
 
-                server.Put("/",
-                           [](const httplib::Request& req, httplib::Response& res)
-                           { res.set_content(req.body, "text/json"); });
+        m_server.Post(
+            "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
 
-                server.Delete(R"(/(\d+))",
-                              [](const httplib::Request& req, httplib::Response& res)
-                              { res.set_content(req.matches[1], "text/json"); });
+        m_server.Put(
+            "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
 
-                server.listen("localhost", 44441);
-            });
-        t.detach();
+        m_server.Delete(R"(/(\d+))",
+                        [](const httplib::Request& req, httplib::Response& res)
+                        { res.set_content(req.matches[1], "text/json"); });
+
+        m_server.set_keep_alive_max_count(1);
+        m_server.listen("localhost", 44441);
     }
 };
 
-EchoServer server;
+FakeServer g_server;
 
 static void BM_Get(benchmark::State& state)
 {

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -23,6 +23,8 @@
 
 #include "HTTPRequest.hpp"
 
+class FakeServer;
+
 class ComponentTest : public ::testing::Test
 {
 protected:
@@ -31,6 +33,21 @@ protected:
     void SetUp() override
     {
         m_callbackComplete = false;
+    }
+
+    inline static std::unique_ptr<FakeServer> fakeFileServer;
+
+    static void SetUpTestSuite()
+    {
+        if (!fakeFileServer)
+        {
+            fakeFileServer = std::make_unique<FakeServer>();
+        }
+    }
+
+    static void TearDownTestSuite()
+    {
+        fakeFileServer.reset();
     }
 };
 


### PR DESCRIPTION
## Description
This PR aims to solve some Valgrind issues discovered under the execution of the unit tests, and ASAN executions.

Basically, the main purpose of this fix is to initialize each instance cURL, based on the cURL documentation arguments to avoid concurrency issues.

![image](https://user-images.githubusercontent.com/14300208/192151470-ab4dd336-83df-405f-b8b0-385c432e4514.png)

Valgrind execution

![image](https://user-images.githubusercontent.com/14300208/192151520-62b063d7-bef6-47fa-ad74-a3bfe17ec5e1.png)

