### PR TITLE
Maintain the CURL handle in a internal cache

### DIFF
--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -433,6 +433,8 @@ TEST_F(ComponentTestInternalParameters, MultipleThreads)
                                     .url("http://localhost:44441/")
                                     .execute());
             });
+
+        EXPECT_LE(HANDLER_QUEUE.size(), QUEUE_SIZE);
     }
 
     for (auto& thread : threads)

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -415,3 +415,28 @@ TEST_F(ComponentTestInternalParameters, ExecuteDeleteNoUrl)
     }
     EXPECT_TRUE(m_callbackComplete);
 }
+
+/**
+ * @brief This test checks the behavior of multiple threads.
+ * This test create multiple threads that exceed the size of the queue where each thread will create a cURLWrapper
+ * object.
+ */
+TEST_F(ComponentTestInternalParameters, MultipleThreads)
+{
+    std::vector<std::thread> threads;
+    for (int i = 0; i < QUEUE_SIZE * 2; ++i)
+    {
+        threads.emplace_back(
+            []()
+            {
+                EXPECT_NO_THROW(GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+                                    .url("http://localhost:44441/")
+                                    .execute());
+            });
+    }
+
+    for (auto& thread : threads)
+    {
+        EXPECT_NO_THROW(thread.join());
+    }
+}


### PR DESCRIPTION
| Related issues |
| --- |
| #17 |

## Description
The objetive of this PR is to improve the performance of the CURL wrapper. For this, a single instance of the wrapper is created per thread and this information is stored in a queue with a size of 5.

## Information
<details><summary>Behavior before the change</summary>

![image](https://user-images.githubusercontent.com/106940255/195578753-d5e280c5-8772-45cc-ba59-b4ab28c4d88b.png)

</details>

<details><summary>Behavior after optimization</summary>

![image](https://user-images.githubusercontent.com/106940255/195578912-eaab1532-c283-43f5-aae0-24c4a521ff77.png)

</details>

<details><summary>Check queue size</summary>

![image](https://user-images.githubusercontent.com/106940255/195579166-d28624c0-680e-44c6-a2cb-9c2a20ad4e9b.png)

</details>

<details><summary>Valgrind</summary>

![image](https://user-images.githubusercontent.com/106940255/195579478-daba4e7b-aa47-41d7-8e67-7ab02eacc482.png)

</details>
