### PR TITLE
Add retry feature for HTTPRequest::get()

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -65,7 +65,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        unsigned int retryAttempts = 1);
+        const unsigned int retryAttempts = 1);
 
     /**
      * @brief Performs a HTTP UPDATE request.

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -58,14 +58,14 @@ public:
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
-     * @param attempts Number of attempts (in total) if the query fails.
+     * @param retryAttempts Number of retry attempts if the query fails.
      */
     void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        unsigned int attempts = 2);
+        unsigned int retryAttempts = 1);
 
     /**
      * @brief Performs a HTTP UPDATE request.

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -58,12 +58,14 @@ public:
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
+     * @param attempts Number of attempts (in total) if the query fails.
      */
     void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        unsigned int attempts = 2);
 
     /**
      * @brief Performs a HTTP UPDATE request.

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -58,14 +58,15 @@ public:
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
-     * @param retryAttempts Number of retry attempts if the query fails.
+     * @param retryAttempts Number of retry attempts if the query fails. By default is zero, meaning no retry will be
+     * made.
      */
     void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        const unsigned int retryAttempts = 1);
+        const unsigned int retryAttempts = 0);
 
     /**
      * @brief Performs a HTTP UPDATE request.

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -147,14 +147,15 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
-     * @param retryAttempts Number of retry attempts if the query fails.
+     * @param retryAttempts Number of retry attempts if the query fails. By default is zero, meaning no retry will be
+     * made.
      */
     virtual void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        const unsigned int retryAttempts = 1) = 0;
+        const unsigned int retryAttempts = 0) = 0;
 
     /**
      * @brief Virtual method to send a UPDATE request to a URL.

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -154,7 +154,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        unsigned int retryAttempts = 1) = 0;
+        const unsigned int retryAttempts = 1) = 0;
 
     /**
      * @brief Virtual method to send a UPDATE request to a URL.

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -147,12 +147,14 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
+     * @param attempts Number of attempts (in total) if the query fails.
      */
     virtual void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
-        const std::string& fileName = "") = 0;
+        const std::string& fileName = "",
+        unsigned int attempts = 2) = 0;
 
     /**
      * @brief Virtual method to send a UPDATE request to a URL.

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -147,14 +147,14 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
-     * @param attempts Number of attempts (in total) if the query fails.
+     * @param retryAttempts Number of retry attempts if the query fails.
      */
     virtual void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        unsigned int attempts = 2) = 0;
+        unsigned int retryAttempts = 1) = 0;
 
     /**
      * @brief Virtual method to send a UPDATE request to a URL.

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -41,7 +41,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        const unsigned int retryAttempts = 1);
+        const unsigned int retryAttempts = 0);
     void update(
         const URL& url,
         const nlohmann::json& data,

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -41,7 +41,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        unsigned int retryAttempts = 1);
+        const unsigned int retryAttempts = 1);
     void update(
         const URL& url,
         const nlohmann::json& data,

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -41,7 +41,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
         const std::string& fileName = "",
-        unsigned int attempts = 2);
+        unsigned int retryAttempts = 1);
     void update(
         const URL& url,
         const nlohmann::json& data,

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -40,7 +40,8 @@ public:
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&)> onError = [](auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        unsigned int attempts = 2);
     void update(
         const URL& url,
         const nlohmann::json& data,

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -61,13 +61,13 @@ void HTTPRequest::post(const URL& url,
 void HTTPRequest::get(const URL& url,
                       std::function<void(const std::string&)> onSuccess,
                       std::function<void(const std::string&)> onError,
-                      const std::string& fileName)
+                      const std::string& fileName,
+                      unsigned int attempts)
 {
-    auto getAttempts {2};
     std::string exceptionMessage;
 
     // Try the request 'getAttempts' times
-    while (0 < getAttempts)
+    while (0 < attempts)
     {
         try
         {
@@ -84,13 +84,13 @@ void HTTPRequest::get(const URL& url,
         }
         catch (const std::exception& ex)
         {
-            getAttempts--;
+            attempts--;
             exceptionMessage = ex.what();
         }
     }
 
     // If all attempts fail, the error callback is called
-    if (0 == getAttempts)
+    if (0 == attempts)
     {
         onError(exceptionMessage);
     }

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -67,7 +67,7 @@ void HTTPRequest::get(const URL& url,
     std::string exceptionMessage;
     unsigned int attempts {1 + retryAttempts};
 
-    // Try the request 'attempts'
+    // Try the request 'attempts' times
     while (0 < attempts)
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -63,11 +63,11 @@ void HTTPRequest::get(const URL& url,
                       std::function<void(const std::string&)> onError,
                       const std::string& fileName)
 {
-    auto fetchAttempts {2};
+    auto getAttempts {2};
     std::string exceptionMessage;
 
-    // Do fetchAttempts attempts to fetch the description
-    while (0 < fetchAttempts)
+    // Do getAttempts attempts to get the description
+    while (0 < getAttempts)
     {
         try
         {
@@ -84,15 +84,15 @@ void HTTPRequest::get(const URL& url,
         }
         catch (const std::exception& ex)
         {
-            fetchAttempts--;
+            getAttempts--;
             exceptionMessage = ex.what();
         }
     }
 
     // If all attempts fail, the error callback is called
-    if (0 == fetchAttempts)
+    if (0 == getAttempts)
     {
-        onError(std::move(exceptionMessage));
+        onError(exceptionMessage);
     }
 }
 

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -65,10 +65,10 @@ void HTTPRequest::get(const URL& url,
                       const unsigned int retryAttempts)
 {
     std::string exceptionMessage;
-    unsigned int attempts {1 + retryAttempts};
+    unsigned int attempts {1u + retryAttempts};
 
     // Try the request 'attempts' times
-    while (0 < attempts)
+    while (0u < attempts)
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
 
@@ -83,7 +83,7 @@ void HTTPRequest::get(const URL& url,
         }
         catch (const std::exception& ex)
         {
-            attempts--;
+            --attempts;
             exceptionMessage += std::string("'") + ex.what() + "' - ";
             continue;
         }
@@ -92,7 +92,7 @@ void HTTPRequest::get(const URL& url,
         break;
     }
 
-    if (0 == attempts)
+    if (0u == attempts)
     {
         // If all attempts fail, the error callback is called
         // Last three chars of the message (" - ") are removed

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -65,6 +65,7 @@ void HTTPRequest::get(const URL& url,
                       unsigned int attempts)
 {
     std::string exceptionMessage;
+    std::string response;
 
     // Try the request 'getAttempts' times
     while (0 < attempts)
@@ -79,7 +80,7 @@ void HTTPRequest::get(const URL& url,
                 .outputFile(fileName)
                 .execute();
 
-            onSuccess(req.response());
+            response = req.response();
             break;
         }
         catch (const std::exception& ex)
@@ -89,10 +90,14 @@ void HTTPRequest::get(const URL& url,
         }
     }
 
-    // If all attempts fail, the error callback is called
     if (0 == attempts)
     {
+        // If all attempts fail, the error callback is called
         onError(exceptionMessage);
+    }
+    else
+    {
+        onSuccess(response);
     }
 }
 

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -86,14 +86,15 @@ void HTTPRequest::get(const URL& url,
         catch (const std::exception& ex)
         {
             attempts--;
-            exceptionMessage = ex.what();
+            exceptionMessage += std::string("'") + ex.what() + "' - ";
         }
     }
 
     if (0 == attempts)
     {
         // If all attempts fail, the error callback is called
-        onError(exceptionMessage);
+        // Last three chars of the message (" - ") are removed
+        onError(exceptionMessage.substr(0, exceptionMessage.size() - 3));
     }
     else
     {

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -66,7 +66,7 @@ void HTTPRequest::get(const URL& url,
     auto getAttempts {2};
     std::string exceptionMessage;
 
-    // Do getAttempts attempts to get the description
+    // Try the request 'getAttempts' times
     while (0 < getAttempts)
     {
         try

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -62,13 +62,13 @@ void HTTPRequest::get(const URL& url,
                       std::function<void(const std::string&)> onSuccess,
                       std::function<void(const std::string&)> onError,
                       const std::string& fileName,
-                      unsigned int retryAttempts)
+                      const unsigned int retryAttempts)
 {
     std::string exceptionMessage;
-    bool firstGet {true};
+    unsigned int attempts {1 + retryAttempts};
 
-    // Try the request 'retryAttempts' + 1 times
-    while (firstGet || 0 < retryAttempts)
+    // Try the request 'attempts'
+    while (0 < attempts)
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
 
@@ -83,12 +83,8 @@ void HTTPRequest::get(const URL& url,
         }
         catch (const std::exception& ex)
         {
-            if (!firstGet)
-            {
-                retryAttempts--;
-            }
+            attempts--;
             exceptionMessage += std::string("'") + ex.what() + "' - ";
-            firstGet = false;
             continue;
         }
 
@@ -96,7 +92,7 @@ void HTTPRequest::get(const URL& url,
         break;
     }
 
-    if (!firstGet && 0 == retryAttempts)
+    if (0 == attempts)
     {
         // If all attempts fail, the error callback is called
         // Last three chars of the message (" - ") are removed

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -65,29 +65,30 @@ void HTTPRequest::get(const URL& url,
                       unsigned int attempts)
 {
     std::string exceptionMessage;
-    std::string response;
 
-    // Try the request 'getAttempts' times
+    // Try the request 'attempts' times
     while (0 < attempts)
     {
+        auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
+
         try
         {
-            auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
             req.url(url.url())
                 .appendHeader("Content-Type: application/json")
                 .appendHeader("Accept: application/json")
                 .appendHeader("Accept-Charset: utf-8")
                 .outputFile(fileName)
                 .execute();
-
-            response = req.response();
-            break;
         }
         catch (const std::exception& ex)
         {
             attempts--;
             exceptionMessage += std::string("'") + ex.what() + "' - ";
+            continue;
         }
+
+        onSuccess(req.response());
+        break;
     }
 
     if (0 == attempts)
@@ -95,10 +96,6 @@ void HTTPRequest::get(const URL& url,
         // If all attempts fail, the error callback is called
         // Last three chars of the message (" - ") are removed
         onError(exceptionMessage.substr(0, exceptionMessage.size() - 3));
-    }
-    else
-    {
-        onSuccess(response);
     }
 }
 

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -59,10 +59,10 @@ void UNIXSocketRequest::get(const URL& url,
                             const unsigned int retryAttempts)
 {
     std::string exceptionMessage;
-    unsigned int attempts {1 + retryAttempts};
+    unsigned int attempts {1u + retryAttempts};
 
     // Try the request 'attempts' times
-    while (0 < attempts)
+    while (0u < attempts)
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
 
@@ -72,7 +72,7 @@ void UNIXSocketRequest::get(const URL& url,
         }
         catch (const std::exception& ex)
         {
-            attempts--;
+            --attempts;
             exceptionMessage += std::string("'") + ex.what() + "' - ";
             continue;
         }
@@ -81,7 +81,7 @@ void UNIXSocketRequest::get(const URL& url,
         break;
     }
 
-    if (0 == attempts)
+    if (0u == attempts)
     {
         // If all attempts fail, the error callback is called
         // Last three chars of the message (" - ") are removed

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -56,10 +56,10 @@ void UNIXSocketRequest::get(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&)> onError,
                             const std::string& fileName,
-                            unsigned int attempts)
+                            unsigned int retryAttempts)
 {
-    // TODO: Implement attempts logic
-    (void)attempts;
+    // TODO: Implement retry attempts logic
+    (void)retryAttempts;
 
     try
     {

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -56,7 +56,7 @@ void UNIXSocketRequest::get(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&)> onError,
                             const std::string& fileName,
-                            unsigned int retryAttempts)
+                            const unsigned int retryAttempts)
 {
     // TODO: Implement retry attempts logic
     (void)retryAttempts;

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -55,7 +55,8 @@ void UNIXSocketRequest::post(const URL& url,
 void UNIXSocketRequest::get(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&)> onError,
-                            const std::string& fileName)
+                            const std::string& fileName,
+                            unsigned int attempts)
 {
     try
     {

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -58,6 +58,9 @@ void UNIXSocketRequest::get(const URL& url,
                             const std::string& fileName,
                             unsigned int attempts)
 {
+    // TODO: Implement attempts logic
+    (void)attempts;
+
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -16,19 +16,20 @@
 
 #include "HTTPRequest.hpp"
 #include "benchmark.h"
+#include <iostream>
 
 /**
  * @brief This class is a simple HTTP server that provides a simple interface to perform HTTP requests.
  */
-class BenchmarkFakeServer final
+class FakeServer final
 {
 private:
     httplib::Server m_server;
     std::thread m_thread;
 
 public:
-    BenchmarkFakeServer()
-        : m_thread(&BenchmarkFakeServer::run, this)
+    FakeServer()
+        : m_thread(&FakeServer::run, this)
     {
         // Wait until server is ready
         while (!m_server.is_running())
@@ -37,7 +38,7 @@ public:
         }
     }
 
-    ~BenchmarkFakeServer()
+    ~FakeServer()
     {
         m_server.stop();
         m_thread.join();
@@ -67,7 +68,7 @@ public:
     }
 };
 
-BenchmarkFakeServer g_server;
+FakeServer g_server;
 
 /**
  * @brief This function is a benchmark test for the HTTP GET request.

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -16,20 +16,19 @@
 
 #include "HTTPRequest.hpp"
 #include "benchmark.h"
-#include <iostream>
 
 /**
  * @brief This class is a simple HTTP server that provides a simple interface to perform HTTP requests.
  */
-class FakeServer final
+class BenchmarkFakeServer final
 {
 private:
     httplib::Server m_server;
     std::thread m_thread;
 
 public:
-    FakeServer()
-        : m_thread(&FakeServer::run, this)
+    BenchmarkFakeServer()
+        : m_thread(&BenchmarkFakeServer::run, this)
     {
         // Wait until server is ready
         while (!m_server.is_running())
@@ -38,7 +37,7 @@ public:
         }
     }
 
-    ~FakeServer()
+    ~BenchmarkFakeServer()
     {
         m_server.stop();
         m_thread.join();
@@ -68,7 +67,7 @@ public:
     }
 };
 
-FakeServer g_server;
+BenchmarkFakeServer g_server;
 
 /**
  * @brief This function is a benchmark test for the HTTP GET request.

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -132,7 +132,9 @@ TEST_F(ComponentTestInterface, GetWithRetry)
         {
             // This should not be executed
             errorCallbackComplete = true;
-        });
+        },
+        "",
+        2);
 
     EXPECT_TRUE(m_callbackComplete);
     EXPECT_FALSE(errorCallbackComplete);

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -105,7 +105,7 @@ TEST_F(ComponentTestInterface, GetIncorrectPort)
         [](auto) {},
         [&](const std::string& result)
         {
-            EXPECT_EQ(result, "Couldn't connect to server");
+            EXPECT_EQ(result, "'Couldn't connect to server' - 'Couldn't connect to server'");
             m_callbackComplete = true;
         });
 

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -119,7 +119,7 @@ TEST_F(ComponentTestInterface, GetIncorrectPort)
  */
 TEST_F(ComponentTestInterface, GetWithRetry)
 {
-    auto onErrorCallback {false};
+    auto errorCallbackComplete {false};
 
     HTTPRequest::instance().get(
         HttpURL("http://localhost:44441/testRetry/"),
@@ -131,11 +131,11 @@ TEST_F(ComponentTestInterface, GetWithRetry)
         [&](const std::string& result)
         {
             // This should not be executed
-            onErrorCallback = true;
+            errorCallbackComplete = true;
         });
 
     EXPECT_TRUE(m_callbackComplete);
-    EXPECT_FALSE(onErrorCallback);
+    EXPECT_FALSE(errorCallbackComplete);
 }
 
 /**

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -62,6 +62,7 @@ public:
                          else
                          {
                              res.set_content("Hello World!", "text/json");
+                             m_forceError = true;
                          }
                      });
 
@@ -134,10 +135,34 @@ TEST_F(ComponentTestInterface, GetWithRetry)
             errorCallbackComplete = true;
         },
         "",
-        2); // This should be greater than one in order to success
+        1); // This should be greater than zero in order to success
 
     EXPECT_TRUE(m_callbackComplete);
     EXPECT_FALSE(errorCallbackComplete);
+}
+
+/**
+ * @brief Test the get request without any retry.
+ *
+ * @details The first (and only) attempt to get() should fail.
+ */
+TEST_F(ComponentTestInterface, GetWithoutRetry)
+{
+    auto errorCallbackComplete {false};
+
+    HTTPRequest::instance().get(
+        HttpURL("http://localhost:44441/testRetry/"),
+        [&](const std::string& result)
+        {
+            // This should not be executed
+            m_callbackComplete = true;
+        },
+        [&](const std::string& result) { errorCallbackComplete = true; },
+        "",
+        0);
+
+    EXPECT_FALSE(m_callbackComplete);
+    EXPECT_TRUE(errorCallbackComplete);
 }
 
 /**

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -134,7 +134,7 @@ TEST_F(ComponentTestInterface, GetWithRetry)
             errorCallbackComplete = true;
         },
         "",
-        2);
+        2); // This should be greater than one in order to success
 
     EXPECT_TRUE(m_callbackComplete);
     EXPECT_FALSE(errorCallbackComplete);

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -97,7 +97,7 @@ TEST_F(ComponentTestInterface, GetHelloWorld)
 }
 
 /**
- * @brief Test the get request from an incorrect port.
+ * @brief Test the get request from an incorrect port. One retry is enabled.
  */
 TEST_F(ComponentTestInterface, GetIncorrectPort)
 {
@@ -108,7 +108,9 @@ TEST_F(ComponentTestInterface, GetIncorrectPort)
         {
             EXPECT_EQ(result, "'Couldn't connect to server' - 'Couldn't connect to server'");
             m_callbackComplete = true;
-        });
+        },
+        "",
+        1);
 
     EXPECT_TRUE(m_callbackComplete);
 }

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -23,7 +23,7 @@
 
 #include "HTTPRequest.hpp"
 
-class FakeServer;
+class ComponentTestFakeServer;
 
 /**
  * @brief Class to test HTTPRequest class.
@@ -47,7 +47,7 @@ protected:
     /**
      * @brief This variable is used to store the server instance.
      */
-    inline static std::unique_ptr<FakeServer> fakeFileServer;
+    inline static std::unique_ptr<ComponentTestFakeServer> fakeFileServer;
 
     /**
      * @brief This method is called before each test to initialize the test environment.
@@ -56,7 +56,7 @@ protected:
     {
         if (!fakeFileServer)
         {
-            fakeFileServer = std::make_unique<FakeServer>();
+            fakeFileServer = std::make_unique<ComponentTestFakeServer>();
         }
     }
 


### PR DESCRIPTION
| Issue |
| --- |
| Closes #24 |

### Description
This PR adds the capability of re-try the HTTP GET process when it fails.
