### PR TITLE
Avoid redefition if this project are used as submodule of another project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.12.4)
 project(urlrequest)
 
-get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/ ABSOLUTE)
+if(NOT SRC_FOLDER)
+    get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/ ABSOLUTE)
+endif(NOT SRC_FOLDER)
 
 set(CMAKE_CXX_STANDARD 17)
 


### PR DESCRIPTION
## Description
This PR aims to solve an issue when this project is used as a submodule of another project.

Basically, the effect of the bug, is that the external folder is created under the component folder, in the case if the component folder is not in the root directory, the issue is reproduced.

