### PR TITLE
Add HTTP headers parameter in HTTPRequest queries

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -39,7 +39,7 @@ public:
         const URL& url,
         const std::string& fileName,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>());
 
     /**
      * @brief Performs a HTTP POST request.

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -89,6 +89,7 @@ public:
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+
     /**
      * @brief Performs a HTTP DELETE request.
      * @param url URL to send the request.

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -16,8 +16,12 @@
 #include "json.hpp"
 #include "singleton.hpp"
 #include <functional>
-#include <iostream>
 #include <string>
+#include <unordered_set>
+
+// HTTP headers used by default in queries.
+const std::unordered_set<std::string> DEFAULT_HEADERS {
+    "Content-Type: application/json", "Accept: application/json", "Accept-Charset: utf-8"};
 
 /**
  * @brief This class is an implementation of IURLRequest.
@@ -33,11 +37,13 @@ public:
      * @param url URL to send the request.
      * @param fileName Output file.
      * @param onError Callback to be called in case of error.
+     * @param httpHeaders Headers to be added to the query.
      */
     void download(
         const URL& url,
         const std::string& fileName,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {});
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
 
     /**
      * @brief Performs a HTTP POST request.
@@ -46,13 +52,15 @@ public:
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     void post(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
 
     /**
      * @brief Performs a HTTP GET request.
@@ -60,12 +68,14 @@ public:
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
 
     /**
      * @brief Performs a HTTP UPDATE request.
@@ -74,26 +84,29 @@ public:
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     void update(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
-
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     /**
      * @brief Performs a HTTP DELETE request.
      * @param url URL to send the request.
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     void delete_(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
 };
 
 #endif // _HTTP_REQUEST_HPP

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -19,10 +19,6 @@
 #include <string>
 #include <unordered_set>
 
-// HTTP headers used by default in queries.
-const std::unordered_set<std::string> DEFAULT_HEADERS {
-    "Content-Type: application/json", "Accept: application/json", "Accept-Charset: utf-8"};
-
 /**
  * @brief This class is an implementation of IURLRequest.
  * It provides a simple interface to perform HTTP requests.

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -15,6 +15,7 @@
 #include "json.hpp"
 #include <functional>
 #include <string>
+#include <unordered_set>
 
 enum SOCKET_TYPE
 {
@@ -122,11 +123,13 @@ public:
      * @param url URL to send the request.
      * @param fileName File name to save the response.
      * @param onError Callback to be called when an error occurs.
+     * @param httpHeaders Headers to be added to the query.
      */
     virtual void download(
         const URL& url,
         const std::string& fileName,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {}) = 0;
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
 
     /**
      * @brief Virtual method to send a POST request to a URL.
@@ -135,13 +138,15 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     virtual void post(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "") = 0;
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
 
     /**
      * @brief Virtual method to send a GET request to a URL.
@@ -149,12 +154,14 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     virtual void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "") = 0;
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
 
     /**
      * @brief Virtual method to send a UPDATE request to a URL.
@@ -163,13 +170,15 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     virtual void update(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "") = 0;
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
 
     /**
      * @brief Virtual method to send a DELETE request to a URL.
@@ -177,12 +186,14 @@ public:
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
      */
     virtual void delete_(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "") = 0;
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
 };
 
 #endif // _URL_REQUEST_HPP

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -23,6 +23,10 @@ enum SOCKET_TYPE
     SOCKET_TCP
 };
 
+// HTTP headers used by default in queries.
+const std::unordered_set<std::string> DEFAULT_HEADERS {
+    "Content-Type: application/json", "Accept: application/json", "Accept-Charset: utf-8"};
+
 /**
  * @brief This class is an abstraction of URL.
  * It is a base class to store the type/configuration of the request to made.
@@ -129,7 +133,7 @@ public:
         const URL& url,
         const std::string& fileName,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
 
     /**
      * @brief Virtual method to send a POST request to a URL.
@@ -146,7 +150,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
 
     /**
      * @brief Virtual method to send a GET request to a URL.
@@ -161,7 +165,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
 
     /**
      * @brief Virtual method to send a UPDATE request to a URL.
@@ -178,7 +182,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
 
     /**
      * @brief Virtual method to send a DELETE request to a URL.
@@ -193,7 +197,7 @@ public:
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
 };
 
 #endif // _URL_REQUEST_HPP

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -133,7 +133,7 @@ public:
         const URL& url,
         const std::string& fileName,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
+        const std::unordered_set<std::string>& httpHeaders = std::unordered_set<std::string>()) = 0;
 
     /**
      * @brief Virtual method to send a POST request to a URL.

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -31,29 +31,34 @@ public:
     void download(
         const URL& url,
         const std::string& fileName,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {});
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void post(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void update(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void delete_(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "");
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
 };
 
 #endif // _UNIX_SOCKET_REQUEST_HPP

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <unordered_set>
 
 /**
  * @brief This class is an abstraction of HTTP Unix socket request.

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -30,7 +30,6 @@ void HTTPRequest::download(const URL& url,
             .outputFile(outputFile)
             .appendHeaders(httpHeaders)
             .execute();
-        auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
     }
     catch (const Curl::CurlException& ex)
     {

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -13,7 +13,6 @@
 #include "factoryRequestImplemetator.hpp"
 #include "json.hpp"
 #include "urlRequest.hpp"
-#include <algorithm>
 #include <string>
 #include <unordered_set>
 
@@ -26,12 +25,12 @@ void HTTPRequest::download(const URL& url,
 {
     try
     {
+        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+            .url(url.url())
+            .outputFile(outputFile)
+            .appendHeaders(httpHeaders)
+            .execute();
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-
-        std::for_each(
-            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
-
-        req.url(url.url()).outputFile(outputFile).execute();
     }
     catch (const Curl::CurlException& ex)
     {
@@ -53,11 +52,7 @@ void HTTPRequest::post(const URL& url,
     try
     {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-
-        std::for_each(
-            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
-
-        req.url(url.url()).postData(data).outputFile(fileName).execute();
+        req.url(url.url()).postData(data).appendHeaders(httpHeaders).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }
@@ -80,11 +75,7 @@ void HTTPRequest::get(const URL& url,
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-
-        std::for_each(
-            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
-
-        req.url(url.url()).outputFile(fileName).execute();
+        req.url(url.url()).appendHeaders(httpHeaders).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }
@@ -108,11 +99,7 @@ void HTTPRequest::update(const URL& url,
     try
     {
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-
-        std::for_each(
-            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
-
-        req.url(url.url()).postData(data).outputFile(fileName).execute();
+        req.url(url.url()).postData(data).appendHeaders(httpHeaders).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }
@@ -135,11 +122,7 @@ void HTTPRequest::delete_(const URL& url,
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
-
-        std::for_each(
-            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
-
-        req.url(url.url()).outputFile(fileName).execute();
+        req.url(url.url()).appendHeaders(httpHeaders).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -11,20 +11,27 @@
 
 #include "HTTPRequest.hpp"
 #include "factoryRequestImplemetator.hpp"
+#include "json.hpp"
 #include "urlRequest.hpp"
+#include <algorithm>
+#include <string>
+#include <unordered_set>
 
 using wrapperType = cURLWrapper;
 
 void HTTPRequest::download(const URL& url,
                            const std::string& outputFile,
-                           std::function<void(const std::string&, const long)> onError)
+                           std::function<void(const std::string&, const long)> onError,
+                           const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
-        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
-            .url(url.url())
-            .outputFile(outputFile)
-            .execute();
+        auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
+
+        std::for_each(
+            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
+
+        req.url(url.url()).outputFile(outputFile).execute();
     }
     catch (const Curl::CurlException& ex)
     {
@@ -40,18 +47,17 @@ void HTTPRequest::post(const URL& url,
                        const nlohmann::json& data,
                        std::function<void(const std::string&)> onSuccess,
                        std::function<void(const std::string&, const long)> onError,
-                       const std::string& fileName)
+                       const std::string& fileName,
+                       const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-        req.url(url.url())
-            .postData(data)
-            .appendHeader("Content-Type: application/json")
-            .appendHeader("Accept: application/json")
-            .appendHeader("Accept-Charset: utf-8")
-            .outputFile(fileName)
-            .execute();
+
+        std::for_each(
+            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
+
+        req.url(url.url()).postData(data).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }
@@ -68,17 +74,17 @@ void HTTPRequest::post(const URL& url,
 void HTTPRequest::get(const URL& url,
                       std::function<void(const std::string&)> onSuccess,
                       std::function<void(const std::string&, const long)> onError,
-                      const std::string& fileName)
+                      const std::string& fileName,
+                      const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-        req.url(url.url())
-            .appendHeader("Content-Type: application/json")
-            .appendHeader("Accept: application/json")
-            .appendHeader("Accept-Charset: utf-8")
-            .outputFile(fileName)
-            .execute();
+
+        std::for_each(
+            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
+
+        req.url(url.url()).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }
@@ -96,18 +102,17 @@ void HTTPRequest::update(const URL& url,
                          const nlohmann::json& data,
                          std::function<void(const std::string&)> onSuccess,
                          std::function<void(const std::string&, const long)> onError,
-                         const std::string& fileName)
+                         const std::string& fileName,
+                         const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-        req.url(url.url())
-            .postData(data)
-            .appendHeader("Content-Type: application/json")
-            .appendHeader("Accept: application/json")
-            .appendHeader("Accept-Charset: utf-8")
-            .outputFile(fileName)
-            .execute();
+
+        std::for_each(
+            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
+
+        req.url(url.url()).postData(data).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }
@@ -124,17 +129,17 @@ void HTTPRequest::update(const URL& url,
 void HTTPRequest::delete_(const URL& url,
                           std::function<void(const std::string&)> onSuccess,
                           std::function<void(const std::string&, const long)> onError,
-                          const std::string& fileName)
+                          const std::string& fileName,
+                          const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
-        req.url(url.url())
-            .appendHeader("Content-Type: application/json")
-            .appendHeader("Accept: application/json")
-            .appendHeader("Accept-Charset: utf-8")
-            .outputFile(fileName)
-            .execute();
+
+        std::for_each(
+            httpHeaders.begin(), httpHeaders.end(), [&req](const std::string& header) { req.appendHeader(header); });
+
+        req.url(url.url()).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -12,13 +12,18 @@
 #include "UNIXSocketRequest.hpp"
 #include "factoryRequestImplemetator.hpp"
 #include "urlRequest.hpp"
+#include <string>
+#include <unordered_set>
 
 using wrapperType = cURLWrapper;
 
 void UNIXSocketRequest::download(const URL& url,
                                  const std::string& outputFile,
-                                 std::function<void(const std::string&, const long)> onError)
+                                 std::function<void(const std::string&, const long)> onError,
+                                 const std::unordered_set<std::string>& httpHeaders)
 {
+    std::ignore = httpHeaders;
+
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -41,8 +46,11 @@ void UNIXSocketRequest::post(const URL& url,
                              const nlohmann::json& data,
                              std::function<void(const std::string&)> onSuccess,
                              std::function<void(const std::string&, const long)> onError,
-                             const std::string& fileName)
+                             const std::string& fileName,
+                             const std::unordered_set<std::string>& httpHeaders)
 {
+    std::ignore = httpHeaders;
+
     try
     {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
@@ -63,8 +71,11 @@ void UNIXSocketRequest::post(const URL& url,
 void UNIXSocketRequest::get(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&, const long)> onError,
-                            const std::string& fileName)
+                            const std::string& fileName,
+                            const std::unordered_set<std::string>& httpHeaders)
 {
+    std::ignore = httpHeaders;
+
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
@@ -86,8 +97,11 @@ void UNIXSocketRequest::update(const URL& url,
                                const nlohmann::json& data,
                                std::function<void(const std::string&)> onSuccess,
                                std::function<void(const std::string&, const long)> onError,
-                               const std::string& fileName)
+                               const std::string& fileName,
+                               const std::unordered_set<std::string>& httpHeaders)
 {
+    std::ignore = httpHeaders;
+
     try
     {
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
@@ -108,8 +122,11 @@ void UNIXSocketRequest::update(const URL& url,
 void UNIXSocketRequest::delete_(const URL& url,
                                 std::function<void(const std::string&)> onSuccess,
                                 std::function<void(const std::string&, const long)> onError,
-                                const std::string& fileName)
+                                const std::string& fileName,
+                                const std::unordered_set<std::string>& httpHeaders)
 {
+    std::ignore = httpHeaders;
+
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -20,10 +20,8 @@ using wrapperType = cURLWrapper;
 void UNIXSocketRequest::download(const URL& url,
                                  const std::string& outputFile,
                                  std::function<void(const std::string&, const long)> onError,
-                                 const std::unordered_set<std::string>& httpHeaders)
+                                 [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
 {
-    std::ignore = httpHeaders;
-
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
@@ -47,10 +45,8 @@ void UNIXSocketRequest::post(const URL& url,
                              std::function<void(const std::string&)> onSuccess,
                              std::function<void(const std::string&, const long)> onError,
                              const std::string& fileName,
-                             const std::unordered_set<std::string>& httpHeaders)
+                             [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
 {
-    std::ignore = httpHeaders;
-
     try
     {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
@@ -72,10 +68,8 @@ void UNIXSocketRequest::get(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&, const long)> onError,
                             const std::string& fileName,
-                            const std::unordered_set<std::string>& httpHeaders)
+                            [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
 {
-    std::ignore = httpHeaders;
-
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
@@ -98,10 +92,8 @@ void UNIXSocketRequest::update(const URL& url,
                                std::function<void(const std::string&)> onSuccess,
                                std::function<void(const std::string&, const long)> onError,
                                const std::string& fileName,
-                               const std::unordered_set<std::string>& httpHeaders)
+                               [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
 {
-    std::ignore = httpHeaders;
-
     try
     {
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
@@ -123,10 +115,8 @@ void UNIXSocketRequest::delete_(const URL& url,
                                 std::function<void(const std::string&)> onSuccess,
                                 std::function<void(const std::string&, const long)> onError,
                                 const std::string& fileName,
-                                const std::unordered_set<std::string>& httpHeaders)
+                                [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
 {
-    std::ignore = httpHeaders;
-
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -17,10 +17,12 @@
 #include "customDeleter.hpp"
 #include "fsWrapper.hpp"
 #include "json.hpp"
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #define NOT_USED -1
@@ -177,6 +179,19 @@ public:
     T& appendHeader(const std::string& header)
     {
         m_requestImplementator->appendHeader(header);
+        return static_cast<T&>(*this);
+    }
+
+    /**
+     * @brief This method appends a set of headers and returns a reference to the object.
+     * @param headers Headers to append.
+     * @return A reference to the object.
+     */
+    T& appendHeaders(const std::unordered_set<std::string>& headers)
+    {
+        std::for_each(headers.begin(),
+                      headers.end(),
+                      [this](const std::string& header) { m_requestImplementator->appendHeader(header); });
         return static_cast<T&>(*this);
     }
 


### PR DESCRIPTION
| Related issue |
| - |
| Closes #41 |

# Description

This PR adds the possibility of appending custom HTTP headers to the HTTP queries implemented on the `HTTPRequest` class.

Change log:
- Add new parameter to the class methods. This parameter is optional and, if not set, default headers will be used.
- Add tests that ensure the changes are working as desired

# Tests

I performed the following test in order to ensure that these changes are not breaking the functionality:
- Created a [branch](https://github.com/wazuh/wazuh/tree/test-http-request-with-header-parameter) on [wazuh/wazuh](https://github.com/wazuh/wazuh) that uses this branch of `http-request`.
- Compiled agent using `make deps TARGET=agent && make TARGET=agent`
- Run the `sysinfo_test_tool` on `src/data_provider/build/bin`

<details><summary>Output of sysinfo_test_tool (TRUNCATED due to being very long)</summary>

```bash
# ./sysinfo_test_tool | head -50 
{
  "hotfixes": null,
  "hw": {
    "board_serial": "NBQ7M11001144D01513400",
    "cpu_cores": 8,
    "cpu_mhz": 900.0,
    "cpu_name": "Intel(R) Core(TM) i5-10300H CPU @ 2.50GHz",
    "ram_free": 7131504,
    "ram_total": 16193864,
    "ram_usage": 56
  },
  "networks": {
    "iface": [
      {
        "IPv4": [
          {
            "address": "172.17.0.2",
            "broadcast": "172.17.255.255",
            "dhcp": "unknown",
            "metric": "0",
            "netmask": "255.255.0.0"
          }
        ],
        "adapter": "",
        "gateway": "172.17.0.1",
        "mac": "02:42:ac:11:00:02",
        "mtu": 1500,
        "name": "eth0",
        "rx_bytes": 338393161,
        "rx_dropped": 0,
        "rx_errors": 0,
        "rx_packets": 226769,
        "state": "up",
        "tx_bytes": 10845515,
        "tx_dropped": 0,
        "tx_errors": 0,
        "tx_packets": 137637,
        "type": "ethernet"
      }
    ]
  },
  "os": {
    "architecture": "x86_64",
    "hostname": "ubuntu-container",
    "os_codename": "jammy",
    "os_major": "22",
    "os_minor": "04",
    "os_name": "Ubuntu",
    "os_patch": "3",
    "os_platform": "ubuntu",
```

<details>