### PR TITLE
Add PATCH query to the HTTPRequest class

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -91,6 +91,24 @@ public:
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
 
     /**
+     * @brief Performs an HTTP PATCH request.
+     *
+     * @param url URL to send the request.
+     * @param data Data to send.
+     * @param onSuccess Callback to be called when the request is successful.
+     * @param onError Callback to be called when an error occurs.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    void patch(
+        const URL& url,
+        const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+
+    /**
      * @brief Performs a HTTP DELETE request.
      * @param url URL to send the request.
      * @param onSuccess Callback to be called in case of success.

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -185,6 +185,24 @@ public:
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
 
     /**
+     * @brief Virtual method to send a PATCH request to a URL.
+     *
+     * @param url URL to send the request.
+     * @param data Data to send.
+     * @param onSuccess Callback to be called when the request is successful.
+     * @param onError Callback to be called when an error occurs.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    virtual void patch(
+        const URL& url,
+        const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
+
+    /**
      * @brief Virtual method to send a DELETE request to a URL.
      * @param url URL to send the request.
      * @param onSuccess Callback to be called when the request is successful.

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -54,6 +54,13 @@ public:
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+    void patch(
+        const URL& url,
+        const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void delete_(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -112,6 +112,34 @@ void HTTPRequest::update(const URL& url,
     }
 }
 
+void HTTPRequest::patch(const URL& url,
+                        const nlohmann::json& data,
+                        std::function<void(const std::string&)> onSuccess,
+                        std::function<void(const std::string&, const long)> onError,
+                        const std::string& fileName,
+                        const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
+        auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
+        req.url(url.url())
+            .postData(data)
+            .appendHeaders(httpHeaders)
+            .outputFile(fileName)
+            .execute();
+
+        onSuccess(req.response());
+    }
+    catch (const Curl::CurlException& ex)
+    {
+        onError(ex.what(), ex.responseCode());
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
 void HTTPRequest::delete_(const URL& url,
                           std::function<void(const std::string&)> onSuccess,
                           std::function<void(const std::string&, const long)> onError,

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -122,11 +122,7 @@ void HTTPRequest::patch(const URL& url,
     try
     {
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
-        req.url(url.url())
-            .postData(data)
-            .appendHeaders(httpHeaders)
-            .outputFile(fileName)
-            .execute();
+        req.url(url.url()).postData(data).appendHeaders(httpHeaders).outputFile(fileName).execute();
 
         onSuccess(req.response());
     }

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -111,6 +111,30 @@ void UNIXSocketRequest::update(const URL& url,
     }
 }
 
+void UNIXSocketRequest::patch(const URL& url,
+                              const nlohmann::json& data,
+                              std::function<void(const std::string&)> onSuccess,
+                              std::function<void(const std::string&, const long)> onError,
+                              const std::string& fileName,
+                              [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
+        auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
+        req.url(url.url()).unixSocketPath(url.unixSocketPath()).postData(data).outputFile(fileName).execute();
+
+        onSuccess(req.response());
+    }
+    catch (const Curl::CurlException& ex)
+    {
+        onError(ex.what(), ex.responseCode());
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
 void UNIXSocketRequest::delete_(const URL& url,
                                 std::function<void(const std::string&)> onSuccess,
                                 std::function<void(const std::string&, const long)> onError,

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -32,11 +32,15 @@ enum METHOD_TYPE
     METHOD_GET,
     METHOD_POST,
     METHOD_PUT,
+    METHOD_PATCH,
     METHOD_DELETE
 };
 
-static const std::map<METHOD_TYPE, std::string> METHOD_TYPE_MAP = {
-    {METHOD_GET, "GET"}, {METHOD_POST, "POST"}, {METHOD_PUT, "PUT"}, {METHOD_DELETE, "DELETE"}};
+static const std::map<METHOD_TYPE, std::string> METHOD_TYPE_MAP = {{METHOD_GET, "GET"},
+                                                                   {METHOD_POST, "POST"},
+                                                                   {METHOD_PUT, "PUT"},
+                                                                   {METHOD_PATCH, "PATCH"},
+                                                                   {METHOD_DELETE, "DELETE"}};
 
 static const std::vector<std::string> DEFAULT_CAINFO_PATHS = {
     "/etc/ssl/certs/ca-certificates.crt",     // Debian systems
@@ -329,6 +333,32 @@ public:
 
     // LCOV_EXCL_START
     virtual ~PutRequest() = default;
+    // LCOV_EXCL_STOP
+};
+
+/**
+ * @brief This class is a wrapper for curl library. It provides a simple interface to perform HTTP PATCH requests.
+ *
+ */
+class PatchRequest final
+    : public cURLRequest<PatchRequest>
+    , public PostData<PatchRequest>
+{
+public:
+    /**
+     * @brief This constructor initializes the PatchRequest object.
+     * @param requestImplementator Shared pointer to the request implementator.
+     */
+    explicit PatchRequest(std::shared_ptr<IRequestImplementator> requestImplementator)
+        : cURLRequest<PatchRequest>(requestImplementator)
+        , PostData<PatchRequest>(requestImplementator)
+    {
+        cURLRequest<PatchRequest>::m_requestImplementator->setOption(OPT_CUSTOMREQUEST,
+                                                                     METHOD_TYPE_MAP.at(METHOD_PATCH));
+    }
+
+    // LCOV_EXCL_START
+    virtual ~PatchRequest() = default;
     // LCOV_EXCL_STOP
 };
 

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -61,6 +61,9 @@ public:
         m_server.Put(
             "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
 
+        m_server.Patch(
+            "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
+
         m_server.Delete(R"(/(\d+))",
                         [](const httplib::Request& req, httplib::Response& res)
                         { res.set_content(req.matches[1], "text/json"); });
@@ -116,6 +119,21 @@ static void BM_Update(benchmark::State& state)
     }
 }
 BENCHMARK(BM_Update);
+
+/**
+ * @brief This function is a benchmark test for the HTTP PATCH request.
+ *
+ * @param state Benchmark state.
+ */
+static void BM_Patch(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        HTTPRequest::instance().patch(
+            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})", [&](const std::string& /*result*/) {});
+    }
+}
+BENCHMARK(BM_Patch);
 
 /**
  * @brief This function is a benchmark test for the HTTP DELETE request.

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -631,3 +631,29 @@ TEST_F(ComponentTestInterface, PutWithCustomHeaders)
 
     EXPECT_TRUE(m_callbackComplete);
 }
+
+/**
+ * @brief Test the basic functionality of a PATCH request.
+ *
+ */
+TEST_F(ComponentTestInterface, PatchSimpleFunctionality)
+{
+    const auto postData = R"({"hello":"world"})"_json;
+
+    auto expectedResponse = R"(
+        {
+            "query": "patch"
+        }
+    )"_json;
+    expectedResponse["payload"] = postData;
+
+    HTTPRequest::instance().patch(HttpURL("http://localhost:44441/"),
+                                  postData,
+                                  [&](const std::string& response)
+                                  {
+                                      EXPECT_EQ(nlohmann::json::parse(response), expectedResponse);
+                                      m_callbackComplete = true;
+                                  });
+
+    EXPECT_TRUE(m_callbackComplete);
+}

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -12,6 +12,7 @@
 #ifndef _COMPONENT_TEST_H
 #define _COMPONENT_TEST_H
 
+#include "json.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <algorithm>
@@ -95,6 +96,16 @@ public:
         m_server.Put("/check-headers",
                      [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
                      { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
+
+        m_server.Patch("/",
+                       [](const httplib::Request& req, httplib::Response& res)
+                       {
+                           nlohmann::json response;
+                           response["query"] = "patch";
+                           response["payload"] = nlohmann::json::parse(req.body);
+
+                           res.set_content(response.dump(), "text/json");
+                       });
 
         m_server.Delete(R"(/(\d+))",
                         [](const httplib::Request& req, httplib::Response& res)

--- a/test_tool/actions.hpp
+++ b/test_tool/actions.hpp
@@ -176,6 +176,47 @@ public:
 };
 
 /**
+ * @brief This class is used to perform a PATCH action.
+ *
+ */
+class PatchAction final : public IAction
+{
+private:
+    std::string m_url;
+    nlohmann::json m_data;
+
+public:
+    /**
+     * @brief Constructor of PatchAction class.
+     *
+     * @param url URL to perform the PATCH request.
+     * @param data Data to send in the PATCH request.
+     */
+    explicit PatchAction(const std::string& url, const nlohmann::json& data)
+        : m_url(url)
+        , m_data(data)
+    {
+    }
+
+    /**
+     * @brief This method is used to perform the PATCH request.
+     *
+     */
+    void execute() override
+    {
+        HTTPRequest::instance().patch(
+            HttpURL(m_url),
+            m_data,
+            [](const std::string& msg) { std::cout << msg << std::endl; },
+            [](const std::string& msg, const long responseCode)
+            {
+                std::cerr << msg << ": " << responseCode << std::endl;
+                throw std::runtime_error(msg);
+            });
+    }
+};
+
+/**
  * @brief This class is used to perform a DELETE action.
  */
 class DeleteAction final : public IAction

--- a/test_tool/factoryAction.hpp
+++ b/test_tool/factoryAction.hpp
@@ -46,6 +46,10 @@ public:
         {
             return std::make_unique<PutAction>(args.url(), args.postArguments());
         }
+        else if (0 == args.type().compare("patch"))
+        {
+            return std::make_unique<PatchAction>(args.url(), args.postArguments());
+        }
         else if (0 == args.type().compare("delete"))
         {
             return std::make_unique<DeleteAction>(args.url());


### PR DESCRIPTION
| Related issue |
| --- |
| Closes #43 |

# Description

This PR adds a new HTTP query: PATCH.

Change log:
- Query implementation.
- Component tests implementation.
- Benchmark implementation.
- Include query in test tool.

# Tests

## Component test

```bash
# ./urlrequest_component_test --gtest_filter=*Patch*
Note: Google Test filter = *Patch*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ComponentTestInterface
[ RUN      ] ComponentTestInterface.PatchSimpleFunctionality
[       OK ] ComponentTestInterface.PatchSimpleFunctionality (5 ms)
[----------] 1 test from ComponentTestInterface (5 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (7 ms total)
[  PASSED  ] 1 test.
```

## Benchmark

```bash
# ./urlrequest_benchmark_test --benchmark_filter=BM_Patch
2023-09-11T15:04:20+00:00
Running ./urlrequest_benchmark_test
Run on (8 X 4500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.73, 1.08, 1.52
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
BM_Patch       132168 ns        80704 ns         8526
```

## Test tool

The project test tool has been executed as well by hitting the [jsonplaceholder](https://jsonplaceholder.typicode.com/) free&fake API:

```bash
# ./urlrequest_testtool -u https://jsonplaceholder.typicode.com/posts/1 -t patch -p post_data.json 
{
  "userId": 1,
  "id": 1,
  "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
  "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto",
  "testing": true
}
```

Content of `post_data.json`:
```bash
# cat post_data.json 
{"testing":true}
```

The same result is obtained using CURL:
```bash
# curl -X PATCH https://jsonplaceholder.typicode.com/posts/1 -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"testing": true}'
{
  "userId": 1,
  "id": 1,
  "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
  "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto",
  "testing": true
}
```