### PR TITLE
Enhance interfaces to receive string parameters

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -44,7 +44,7 @@ public:
     /**
      * @brief Performs a HTTP POST request.
      * @param url URL to send the request.
-     * @param data Data to send.
+     * @param data Data to send (nlohmann::json).
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
@@ -53,6 +53,23 @@ public:
     void post(
         const URL& url,
         const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+
+    /**
+     * @brief Performs a HTTP POST request.
+     * @param url URL to send the request.
+     * @param data Data to send (string).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    void post(
+        const URL& url,
+        const std::string& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
@@ -76,13 +93,48 @@ public:
     /**
      * @brief Performs a HTTP UPDATE request.
      * @param url URL to send the request.
-     * @param data Data to send.
+     * @param data Data to send (nlohmann::json).
      * @param onSuccess Callback to be called in case of success.
      * @param onError Callback to be called in case of error.
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      */
-    void update(
+    void put(
+        const URL& url,
+        const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+
+    /**
+     * @brief Performs a HTTP UPDATE request.
+     * @param url URL to send the request.
+     * @param data Data to send (std::string).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    void put(
+        const URL& url,
+        const std::string& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+
+    /**
+     * @brief Performs an HTTP PATCH request.
+     *
+     * @param url URL to send the request.
+     * @param data Data to send (nlohmann::json).
+     * @param onSuccess Callback to be called when the request is successful.
+     * @param onError Callback to be called when an error occurs.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    void patch(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
@@ -94,7 +146,7 @@ public:
      * @brief Performs an HTTP PATCH request.
      *
      * @param url URL to send the request.
-     * @param data Data to send.
+     * @param data Data to send (std::string).
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
@@ -102,7 +154,7 @@ public:
      */
     void patch(
         const URL& url,
-        const nlohmann::json& data,
+        const std::string& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -138,7 +138,7 @@ public:
     /**
      * @brief Virtual method to send a POST request to a URL.
      * @param url URL to send the request.
-     * @param data Data to send.
+     * @param data Data to send (nlohmann::json).
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
@@ -147,6 +147,23 @@ public:
     virtual void post(
         const URL& url,
         const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
+
+    /**
+     * @brief Virtual method to send a POST request to a URL.
+     * @param url URL to send the request.
+     * @param data Data to send (string).
+     * @param onSuccess Callback to be called when the request is successful.
+     * @param onError Callback to be called when an error occurs.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    virtual void post(
+        const URL& url,
+        const std::string& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
@@ -170,13 +187,48 @@ public:
     /**
      * @brief Virtual method to send a UPDATE request to a URL.
      * @param url URL to send the request.
-     * @param data Data to send.
+     * @param data Data to sendi (nlohmann::json).
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      */
-    virtual void update(
+    virtual void put(
+        const URL& url,
+        const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
+
+    /**
+     * @brief Virtual method to send a UPDATE request to a URL.
+     * @param url URL to send the request.
+     * @param data Data to send (string).
+     * @param onSuccess Callback to be called when the request is successful.
+     * @param onError Callback to be called when an error occurs.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    virtual void put(
+        const URL& url,
+        const std::string& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS) = 0;
+
+    /**
+     * @brief Virtual method to send a PATCH request to a URL.
+     *
+     * @param url URL to send the request.
+     * @param data Data to send (nlohmann::json).
+     * @param onSuccess Callback to be called when the request is successful.
+     * @param onError Callback to be called when an error occurs.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     */
+    virtual void patch(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
@@ -188,7 +240,7 @@ public:
      * @brief Virtual method to send a PATCH request to a URL.
      *
      * @param url URL to send the request.
-     * @param data Data to send.
+     * @param data Data to send (string).
      * @param onSuccess Callback to be called when the request is successful.
      * @param onError Callback to be called when an error occurs.
      * @param fileName File name of output file.
@@ -196,7 +248,7 @@ public:
      */
     virtual void patch(
         const URL& url,
-        const nlohmann::json& data,
+        const std::string& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -41,13 +41,34 @@ public:
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+    void post(
+        const URL& url,
+        const std::string& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void get(
         const URL& url,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
-    void update(
+    void put(
+        const URL& url,
+        const nlohmann::json& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+    void put(
+        const URL& url,
+        const std::string& data,
+        std::function<void(const std::string&)> onSuccess,
+        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
+        const std::string& fileName = "",
+        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
+    void patch(
         const URL& url,
         const nlohmann::json& data,
         std::function<void(const std::string&)> onSuccess,
@@ -56,7 +77,7 @@ public:
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS);
     void patch(
         const URL& url,
-        const nlohmann::json& data,
+        const std::string& data,
         std::function<void(const std::string&)> onSuccess,
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::string& fileName = "",

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -50,6 +50,23 @@ void HTTPRequest::post(const URL& url,
 {
     try
     {
+        post(url, data.dump(), onSuccess, onError, fileName, httpHeaders);
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
+void HTTPRequest::post(const URL& url,
+                       const std::string& data,
+                       std::function<void(const std::string&)> onSuccess,
+                       std::function<void(const std::string&, const long)> onError,
+                       const std::string& fileName,
+                       const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
         req.url(url.url()).postData(data).appendHeaders(httpHeaders).outputFile(fileName).execute();
 
@@ -88,12 +105,29 @@ void HTTPRequest::get(const URL& url,
     }
 }
 
-void HTTPRequest::update(const URL& url,
-                         const nlohmann::json& data,
-                         std::function<void(const std::string&)> onSuccess,
-                         std::function<void(const std::string&, const long)> onError,
-                         const std::string& fileName,
-                         const std::unordered_set<std::string>& httpHeaders)
+void HTTPRequest::put(const URL& url,
+                      const nlohmann::json& data,
+                      std::function<void(const std::string&)> onSuccess,
+                      std::function<void(const std::string&, const long)> onError,
+                      const std::string& fileName,
+                      const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
+        put(url, data.dump(), onSuccess, onError, fileName, httpHeaders);
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
+void HTTPRequest::put(const URL& url,
+                      const std::string& data,
+                      std::function<void(const std::string&)> onSuccess,
+                      std::function<void(const std::string&, const long)> onError,
+                      const std::string& fileName,
+                      const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -114,6 +148,23 @@ void HTTPRequest::update(const URL& url,
 
 void HTTPRequest::patch(const URL& url,
                         const nlohmann::json& data,
+                        std::function<void(const std::string&)> onSuccess,
+                        std::function<void(const std::string&, const long)> onError,
+                        const std::string& fileName,
+                        const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
+        patch(url, data.dump(), onSuccess, onError, fileName, httpHeaders);
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
+void HTTPRequest::patch(const URL& url,
+                        const std::string& data,
                         std::function<void(const std::string&)> onSuccess,
                         std::function<void(const std::string&, const long)> onError,
                         const std::string& fileName,

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -49,6 +49,23 @@ void UNIXSocketRequest::post(const URL& url,
 {
     try
     {
+        post(url, data.dump(), onSuccess, onError, fileName, httpHeaders);
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
+void UNIXSocketRequest::post(const URL& url,
+                             const std::string& data,
+                             std::function<void(const std::string&)> onSuccess,
+                             std::function<void(const std::string&, const long)> onError,
+                             const std::string& fileName,
+                             [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
         req.url(url.url()).unixSocketPath(url.unixSocketPath()).postData(data).outputFile(fileName).execute();
 
@@ -87,12 +104,29 @@ void UNIXSocketRequest::get(const URL& url,
     }
 }
 
-void UNIXSocketRequest::update(const URL& url,
-                               const nlohmann::json& data,
-                               std::function<void(const std::string&)> onSuccess,
-                               std::function<void(const std::string&, const long)> onError,
-                               const std::string& fileName,
-                               [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+void UNIXSocketRequest::put(const URL& url,
+                            const nlohmann::json& data,
+                            std::function<void(const std::string&)> onSuccess,
+                            std::function<void(const std::string&, const long)> onError,
+                            const std::string& fileName,
+                            [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
+        put(url, data.dump(), onSuccess, onError, fileName, httpHeaders);
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
+void UNIXSocketRequest::put(const URL& url,
+                            const std::string& data,
+                            std::function<void(const std::string&)> onSuccess,
+                            std::function<void(const std::string&, const long)> onError,
+                            const std::string& fileName,
+                            [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -113,6 +147,23 @@ void UNIXSocketRequest::update(const URL& url,
 
 void UNIXSocketRequest::patch(const URL& url,
                               const nlohmann::json& data,
+                              std::function<void(const std::string&)> onSuccess,
+                              std::function<void(const std::string&, const long)> onError,
+                              const std::string& fileName,
+                              [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+{
+    try
+    {
+        patch(url, data.dump(), onSuccess, onError, fileName, httpHeaders);
+    }
+    catch (const std::exception& ex)
+    {
+        onError(ex.what(), NOT_USED);
+    }
+}
+
+void UNIXSocketRequest::patch(const URL& url,
+                              const std::string& data,
                               std::function<void(const std::string&)> onSuccess,
                               std::function<void(const std::string&, const long)> onError,
                               const std::string& fileName,

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -20,7 +20,7 @@ using wrapperType = cURLWrapper;
 void UNIXSocketRequest::download(const URL& url,
                                  const std::string& outputFile,
                                  std::function<void(const std::string&, const long)> onError,
-                                 [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                                 const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -45,7 +45,7 @@ void UNIXSocketRequest::post(const URL& url,
                              std::function<void(const std::string&)> onSuccess,
                              std::function<void(const std::string&, const long)> onError,
                              const std::string& fileName,
-                             [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                             const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -62,7 +62,7 @@ void UNIXSocketRequest::post(const URL& url,
                              std::function<void(const std::string&)> onSuccess,
                              std::function<void(const std::string&, const long)> onError,
                              const std::string& fileName,
-                             [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                             const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -85,7 +85,7 @@ void UNIXSocketRequest::get(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&, const long)> onError,
                             const std::string& fileName,
-                            [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                            const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -109,7 +109,7 @@ void UNIXSocketRequest::put(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&, const long)> onError,
                             const std::string& fileName,
-                            [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                            const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -126,7 +126,7 @@ void UNIXSocketRequest::put(const URL& url,
                             std::function<void(const std::string&)> onSuccess,
                             std::function<void(const std::string&, const long)> onError,
                             const std::string& fileName,
-                            [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                            const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -150,7 +150,7 @@ void UNIXSocketRequest::patch(const URL& url,
                               std::function<void(const std::string&)> onSuccess,
                               std::function<void(const std::string&, const long)> onError,
                               const std::string& fileName,
-                              [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                              const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -167,7 +167,7 @@ void UNIXSocketRequest::patch(const URL& url,
                               std::function<void(const std::string&)> onSuccess,
                               std::function<void(const std::string&, const long)> onError,
                               const std::string& fileName,
-                              [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                              const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {
@@ -190,7 +190,7 @@ void UNIXSocketRequest::delete_(const URL& url,
                                 std::function<void(const std::string&)> onSuccess,
                                 std::function<void(const std::string&, const long)> onError,
                                 const std::string& fileName,
-                                [[maybe_unused]] const std::unordered_set<std::string>& httpHeaders)
+                                const std::unordered_set<std::string>& httpHeaders)
 {
     try
     {

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -277,13 +277,11 @@ public:
      * @param postData Post data to set.
      * @return A reference to the object.
      */
-    T& postData(const nlohmann::json& postData)
+    T& postData(const std::string& postData)
     {
-        m_postDataString = postData.dump();
+        m_handleReference->setOption(OPT_POSTFIELDS, postData);
 
-        m_handleReference->setOption(OPT_POSTFIELDS, m_postDataString);
-
-        m_handleReference->setOption(OPT_POSTFIELDSIZE, m_postDataString.size());
+        m_handleReference->setOption(OPT_POSTFIELDSIZE, postData.size());
 
         return static_cast<T&>(*this);
     }

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -100,7 +100,7 @@ static void BM_Post(benchmark::State& state)
     for (auto _ : state)
     {
         HTTPRequest::instance().post(
-            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})", [&](const std::string& /*result*/) {});
+            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})"_json, [&](const std::string& /*result*/) {});
     }
 }
 BENCHMARK(BM_Post);
@@ -114,8 +114,8 @@ static void BM_Update(benchmark::State& state)
 {
     for (auto _ : state)
     {
-        HTTPRequest::instance().update(
-            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})", [&](const std::string& /*result*/) {});
+        HTTPRequest::instance().put(
+            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})"_json, [&](const std::string& /*result*/) {});
     }
 }
 BENCHMARK(BM_Update);
@@ -130,7 +130,7 @@ static void BM_Patch(benchmark::State& state)
     for (auto _ : state)
     {
         HTTPRequest::instance().patch(
-            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})", [&](const std::string& /*result*/) {});
+            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})"_json, [&](const std::string& /*result*/) {});
     }
 }
 BENCHMARK(BM_Patch);

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -68,13 +68,13 @@ TEST_F(ComponentTestInterface, PostHelloWorld)
  */
 TEST_F(ComponentTestInterface, PutHelloWorld)
 {
-    HTTPRequest::instance().update(HttpURL("http://localhost:44441/"),
-                                   R"({"hello":"world"})"_json,
-                                   [&](const std::string& result)
-                                   {
-                                       EXPECT_EQ(result, R"({"hello":"world"})");
-                                       m_callbackComplete = true;
-                                   });
+    HTTPRequest::instance().put(HttpURL("http://localhost:44441/"),
+                                R"({"hello":"world"})"_json,
+                                [&](const std::string& result)
+                                {
+                                    EXPECT_EQ(result, R"({"hello":"world"})");
+                                    m_callbackComplete = true;
+                                });
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -235,7 +235,7 @@ TEST_F(ComponentTestInterface, PostHelloWorldFileEmptyURL)
  */
 TEST_F(ComponentTestInterface, PutHelloWorldFile)
 {
-    HTTPRequest::instance().update(
+    HTTPRequest::instance().put(
         HttpURL("http://localhost:44441/"),
         R"({"hello":"world"})"_json,
         [&](const std::string& result) { std::cout << result << std::endl; },
@@ -253,7 +253,7 @@ TEST_F(ComponentTestInterface, PutHelloWorldFile)
  */
 TEST_F(ComponentTestInterface, PutHelloWorldFileEmptyURL)
 {
-    HTTPRequest::instance().update(
+    HTTPRequest::instance().put(
         HttpURL(""),
         R"({"hello":"world"})"_json,
         [&](const std::string& result) { std::cout << result << std::endl; },
@@ -383,7 +383,7 @@ TEST_F(ComponentTestInternalParameters, PostError)
     {
         PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())
             .url("http://localhost:44441/invalid_file")
-            .postData(R"({"hello":"world"})"_json)
+            .postData(R"({"hello":"world"})")
             .execute();
     }
     catch (const std::exception& ex)
@@ -403,7 +403,7 @@ TEST_F(ComponentTestInternalParameters, PutError)
     {
         PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())
             .url("http://localhost:44441/invalid_file")
-            .postData(R"({"hello":"world"})"_json)
+            .postData(R"({"hello":"world"})")
             .execute();
     }
     catch (const std::exception& ex)
@@ -591,7 +591,7 @@ TEST_F(ComponentTestInterface, PostWithCustomHeaders)
 
     HTTPRequest::instance().post(
         HttpURL("http://localhost:44441/check-headers"),
-        "",
+        std::string(),
         [&](const std::string& result)
         {
             const auto response = nlohmann::json::parse(result);
@@ -617,9 +617,9 @@ TEST_F(ComponentTestInterface, PutWithCustomHeaders)
     const std::string headerKey {"Custom-Key"};
     const std::string headerValue {"Custom-Value"};
 
-    HTTPRequest::instance().update(
+    HTTPRequest::instance().put(
         HttpURL("http://localhost:44441/check-headers"),
-        "",
+        std::string(),
         [&](const std::string& result)
         {
             ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), headerValue);

--- a/test/unit/mocks/MockRequestImplementator.hpp
+++ b/test/unit/mocks/MockRequestImplementator.hpp
@@ -50,4 +50,3 @@ public:
 };
 
 #endif // _MOCKREQUESTIMPLEMENTATOR_HPP
-

--- a/test/unit/unit_test.cpp
+++ b/test/unit/unit_test.cpp
@@ -142,7 +142,7 @@ TEST_F(UrlRequestUnitTest, PostApiRequestWithPostFields)
         .userAgent("Wazuh-Agent/1.0")
         .certificate("cert.ca")
         .timeout(10)
-        .postData(R"({"name":"wazuh"})"_json)
+        .postData(R"({"name":"wazuh"})")
         .execute();
 }
 
@@ -171,7 +171,7 @@ TEST_F(UrlRequestUnitTest, PostApiRequestWithPostFieldsAndUnixSocket)
         .userAgent("Wazuh-Agent/1.0")
         .certificate("cert.ca")
         .timeout(10)
-        .postData(R"({"name":"wazuh"})"_json)
+        .postData(R"({"name":"wazuh"})")
         .unixSocketPath("/tmp/wazuh-agent.sock")
         .execute();
 }

--- a/test/unit/unit_test.cpp
+++ b/test/unit/unit_test.cpp
@@ -326,4 +326,3 @@ TEST_F(UrlRequestUnitTest, HttpsNoCertNotExists)
     EXPECT_CALL(getRequestNoCert, exists(_)).Times(5).WillRepeatedly(Return(false));
     EXPECT_NO_THROW(getRequestNoCert.url("https://www.wazuh.com/").execute());
 }
-

--- a/test_tool/actions.hpp
+++ b/test_tool/actions.hpp
@@ -163,7 +163,7 @@ public:
      */
     void execute() override
     {
-        HTTPRequest::instance().update(
+        HTTPRequest::instance().put(
             HttpURL(m_url),
             m_data,
             [](const std::string& msg) { std::cout << msg << std::endl; },


### PR DESCRIPTION
This PR aims to add another option to receive a different format than nlohmann::json, in another real-world scenario (for example the usage of ndjson for bulk API of OpenSearch) is necessary a more versatile type (such string).