### PR TITLE
Adding the authentication options to the test tool

### DIFF
--- a/test_tool/actions.hpp
+++ b/test_tool/actions.hpp
@@ -12,7 +12,6 @@
 #ifndef _ACTION_HPP
 #define _ACTION_HPP
 #include "HTTPRequest.hpp"
-#include "curlException.hpp"
 #include <iostream>
 
 /**

--- a/test_tool/actions.hpp
+++ b/test_tool/actions.hpp
@@ -37,16 +37,25 @@ class DownloadAction final : public IAction
 private:
     std::string m_url;
     std::string m_outputFile;
+    std::unordered_set<std::string> m_headers;
+    SecureCommunication m_secureCommunication;
 
 public:
     /**
      * @brief Constructor for DownloadAction class.
      * @param url URL to download.
      * @param outputFile Output file.
+     * @param headers Headers to send in the request.
+     * @param secureCommunication Secure communication settings.
      */
-    explicit DownloadAction(const std::string& url, const std::string& outputFile)
+    explicit DownloadAction(const std::string& url,
+                            const std::string& outputFile,
+                            const std::unordered_set<std::string>& headers,
+                            const SecureCommunication& secureCommunication)
         : m_url(url)
         , m_outputFile(outputFile)
+        , m_headers(headers)
+        , m_secureCommunication(secureCommunication)
     {
     }
 
@@ -55,13 +64,16 @@ public:
      */
     void execute() override
     {
-        HTTPRequest::instance().download(HttpURL(m_url),
-                                         m_outputFile,
-                                         [](const std::string& msg, const long responseCode)
-                                         {
-                                             std::cerr << msg << ": " << responseCode << std::endl;
-                                             throw std::runtime_error(msg);
-                                         });
+        HTTPRequest::instance().download(
+            HttpURL(m_url),
+            m_outputFile,
+            [](const std::string& msg, const long responseCode)
+            {
+                std::cerr << msg << ": " << responseCode << std::endl;
+                throw std::runtime_error(msg);
+            },
+            m_headers,
+            m_secureCommunication);
     }
 };
 
@@ -72,14 +84,22 @@ class GetAction final : public IAction
 {
 private:
     std::string m_url;
+    std::unordered_set<std::string> m_headers;
+    SecureCommunication m_secureCommunication;
 
 public:
     /**
      * @brief Constructor of GetAction class.
      * @param url URL to perform the GET request.
+     * @param headers Headers to send in the request.
+     * @param secureCommunication Secure communication settings.
      */
-    explicit GetAction(const std::string& url)
+    explicit GetAction(const std::string& url,
+                       const std::unordered_set<std::string>& headers,
+                       const SecureCommunication& secureCommunication)
         : m_url(url)
+        , m_headers(headers)
+        , m_secureCommunication(secureCommunication)
     {
     }
 
@@ -95,7 +115,10 @@ public:
             {
                 std::cerr << msg << ": " << responseCode << std::endl;
                 throw std::runtime_error(msg);
-            });
+            },
+            "",
+            m_headers,
+            m_secureCommunication);
     }
 };
 
@@ -107,16 +130,25 @@ class PostAction final : public IAction
 private:
     std::string m_url;
     nlohmann::json m_data;
+    std::unordered_set<std::string> m_headers;
+    SecureCommunication m_secureCommunication;
 
 public:
     /**
      * @brief Constructor of PostAction class.
      * @param url URL to perform the POST request.
      * @param data Data to send in the POST request.
+     * @param headers Headers to send in the request.
+     * @param secureCommunication Secure communication settings.
      */
-    explicit PostAction(const std::string& url, const nlohmann::json& data)
+    explicit PostAction(const std::string& url,
+                        const nlohmann::json& data,
+                        const std::unordered_set<std::string>& headers,
+                        const SecureCommunication& secureCommunication)
         : m_url(url)
         , m_data(data)
+        , m_headers(headers)
+        , m_secureCommunication(secureCommunication)
     {
     }
 
@@ -133,7 +165,10 @@ public:
             {
                 std::cerr << msg << ": " << responseCode << std::endl;
                 throw std::runtime_error(msg);
-            });
+            },
+            "",
+            m_headers,
+            m_secureCommunication);
     }
 };
 
@@ -145,16 +180,25 @@ class PutAction final : public IAction
 private:
     std::string m_url;
     nlohmann::json m_data;
+    std::unordered_set<std::string> m_headers;
+    SecureCommunication m_secureCommunication;
 
 public:
     /**
      * @brief Constructor of PutAction class.
      * @param url URL to perform the PUT request.
      * @param data Data to send in the PUT request.
+     * @param headers Headers to send in the request.
+     * @param secureCommunication Secure communication settings.
      */
-    explicit PutAction(const std::string& url, const nlohmann::json& data)
+    explicit PutAction(const std::string& url,
+                       const nlohmann::json& data,
+                       const std::unordered_set<std::string>& headers,
+                       const SecureCommunication& secureCommunication)
         : m_url(url)
         , m_data(data)
+        , m_headers(headers)
+        , m_secureCommunication(secureCommunication)
     {
     }
 
@@ -171,7 +215,10 @@ public:
             {
                 std::cerr << msg << ": " << responseCode << std::endl;
                 throw std::runtime_error(msg);
-            });
+            },
+            "",
+            m_headers,
+            m_secureCommunication);
     }
 };
 
@@ -184,6 +231,8 @@ class PatchAction final : public IAction
 private:
     std::string m_url;
     nlohmann::json m_data;
+    std::unordered_set<std::string> m_headers;
+    SecureCommunication m_secureCommunication;
 
 public:
     /**
@@ -191,10 +240,17 @@ public:
      *
      * @param url URL to perform the PATCH request.
      * @param data Data to send in the PATCH request.
+     * @param headers Headers to send in the request.
+     * @param secureCommunication Secure communication settings.
      */
-    explicit PatchAction(const std::string& url, const nlohmann::json& data)
+    explicit PatchAction(const std::string& url,
+                         const nlohmann::json& data,
+                         const std::unordered_set<std::string>& headers,
+                         const SecureCommunication& secureCommunication)
         : m_url(url)
         , m_data(data)
+        , m_headers(headers)
+        , m_secureCommunication(secureCommunication)
     {
     }
 
@@ -212,7 +268,10 @@ public:
             {
                 std::cerr << msg << ": " << responseCode << std::endl;
                 throw std::runtime_error(msg);
-            });
+            },
+            "",
+            m_headers,
+            m_secureCommunication);
     }
 };
 
@@ -223,14 +282,22 @@ class DeleteAction final : public IAction
 {
 private:
     std::string m_url;
+    std::unordered_set<std::string> m_headers;
+    SecureCommunication m_secureCommunication;
 
 public:
     /**
      * @brief Constructor of DeleteAction class.
      * @param url URL to perform the DELETE request.
+     * @param headers Headers to send in the request.
+     * @param secureCommunication Secure communication settings.
      */
-    explicit DeleteAction(const std::string& url)
+    explicit DeleteAction(const std::string& url,
+                          const std::unordered_set<std::string>& headers,
+                          const SecureCommunication& secureCommunication)
         : m_url(url)
+        , m_headers(headers)
+        , m_secureCommunication(secureCommunication)
     {
     }
 
@@ -246,7 +313,10 @@ public:
             {
                 std::cerr << msg << ": " << responseCode << std::endl;
                 throw std::runtime_error(msg);
-            });
+            },
+            "",
+            m_headers,
+            m_secureCommunication);
     }
 };
 

--- a/test_tool/cmdArgsParser.hpp
+++ b/test_tool/cmdArgsParser.hpp
@@ -16,7 +16,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
 
 /**
  * @brief Class to parse command line arguments.
@@ -140,35 +139,38 @@ public:
      */
     static void showHelp()
     {
-        std::cout << "\nUsage: urlrequester_testtool <option(s)> SOURCES \n"
-                  << "Options:\n"
-                  << "\t-h \t\t\tShow this help message\n"
-                  << "\t-u URL_ADDRESS\t\tSpecifies the URL of the file to download or the RESTful address.\n"
-                  << "\t-t TYPE\t\t\tSpecifies the type of action to execute [download, post, get, put, delete].\n"
-                  << "\t-p JSON_FILE\t\tSpecifies the file containing the JSON data to send in the POST request.\n"
-                  << "\t-o OUTPUT_FILE\t\tSpecifies the output file of the downloaded file.\n"
-                  << "\t-H HEADERS\t\tSpecifies the headers to send in the request. If not preset, DEFAULT_HEADERS will be used.\n"
-                  << "\t--cacert CACERT\t\tSpecifies the CA certificate file to use in the request.\n"
-                  << "\t--cert CERT\t\tSpecifies the certificate file to use in the request.\n"
-                  << "\t--key KEY\t\tSpecifies the key file to use in the request.\n"
-                  << "\t--username USERNAME\tSpecifies the username to use in the request.\n"
-                  << "\t--password PASSWORD\tSpecifies the password to use in the request.\n"
-                  << "\nExample:"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t download -o out \n"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get\n"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/post -t post -p input.json\n"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/put -t put -p input.json\n"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/delete -t delete\n"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get -H \"Authorization: Bearer token\"\n"
-                  << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get --cacert cacert.pem --cert cert.pem --key key.pem --username admin --password admin\n"
-                  << std::endl;
+        std::cout
+            << "\nUsage: urlrequester_testtool <option(s)> SOURCES \n"
+            << "Options:\n"
+            << "\t-h \t\t\tShow this help message\n"
+            << "\t-u URL_ADDRESS\t\tSpecifies the URL of the file to download or the RESTful address.\n"
+            << "\t-t TYPE\t\t\tSpecifies the type of action to execute [download, post, get, put, delete].\n"
+            << "\t-p JSON_FILE\t\tSpecifies the file containing the JSON data to send in the POST request.\n"
+            << "\t-o OUTPUT_FILE\t\tSpecifies the output file of the downloaded file.\n"
+            << "\t-H HEADERS\t\tSpecifies the headers to send in the request. If not preset, DEFAULT_HEADERS will be "
+               "used.\n"
+            << "\t--cacert CACERT\t\tSpecifies the CA certificate file to use in the request.\n"
+            << "\t--cert CERT\t\tSpecifies the certificate file to use in the request.\n"
+            << "\t--key KEY\t\tSpecifies the key file to use in the request.\n"
+            << "\t--username USERNAME\tSpecifies the username to use in the request.\n"
+            << "\t--password PASSWORD\tSpecifies the password to use in the request.\n"
+            << "\nExample:"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t download -o out \n"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get\n"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/post -t post -p input.json\n"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/put -t put -p input.json\n"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/delete -t delete\n"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get -H \"Authorization: Bearer token\"\n"
+            << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get --cacert cacert.pem --cert cert.pem "
+               "--key key.pem --username admin --password admin\n"
+            << std::endl;
     }
 
 private:
     static std::string paramValueOf(const int argc,
                                     const char* argv[],
                                     const std::string& switchValue,
-                                    const std::pair<bool, std::string> required = std::make_pair(true, ""))
+                                    const std::pair<bool, std::string>& required = std::make_pair(true, ""))
     {
         for (int i = 1; i < argc; ++i)
         {

--- a/test_tool/cmdArgsParser.hpp
+++ b/test_tool/cmdArgsParser.hpp
@@ -33,6 +33,12 @@ public:
         : m_url {paramValueOf(argc, argv, "-u")}
         , m_outputFile {paramValueOf(argc, argv, "-o", {false, ""})}
         , m_type {paramValueOf(argc, argv, "-t")}
+        , m_headers {paramValueOf(argc, argv, "-H", {false, ""})}
+        , m_cacert {paramValueOf(argc, argv, "--cacert", {false, ""})}
+        , m_cert {paramValueOf(argc, argv, "--cert", {false, ""})}
+        , m_key {paramValueOf(argc, argv, "--key", {false, ""})}
+        , m_username {paramValueOf(argc, argv, "--username", {false, ""})}
+        , m_password {paramValueOf(argc, argv, "--password", {false, ""})}
     {
         auto postArgumentsFile {paramValueOf(argc, argv, "-p", {false, ""})};
 
@@ -82,6 +88,54 @@ public:
     }
 
     /**
+     * @brief Returns the headers.
+     */
+    const std::string& headers() const
+    {
+        return m_headers;
+    }
+
+    /**
+     * @brief Returns the cacert.
+     */
+    const std::string& cacert() const
+    {
+        return m_cacert;
+    }
+
+    /**
+     * @brief Returns the cert.
+     */
+    const std::string& cert() const
+    {
+        return m_cert;
+    }
+
+    /**
+     * @brief Returns the key.
+     */
+    const std::string& key() const
+    {
+        return m_key;
+    }
+
+    /**
+     * @brief Returns the username.
+     */
+    const std::string& username() const
+    {
+        return m_username;
+    }
+
+    /**
+     * @brief Returns the password.
+     */
+    const std::string& password() const
+    {
+        return m_password;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -89,16 +143,24 @@ public:
         std::cout << "\nUsage: urlrequester_testtool <option(s)> SOURCES \n"
                   << "Options:\n"
                   << "\t-h \t\t\tShow this help message\n"
-                  << "\t-u URL_ADDRESS\tSpecifies the URL of the file to download or the RESTful address.\n"
-                  << "\t-t TYPE\t\tSpecifies the type of action to execute [download, post, get, put, delete].\n"
-                  << "\t-p JSON_FILE\tSpecifies the file containing the JSON data to send in the POST request.\n"
-                  << "\t-o OUTPUT_FILE\tSpecifies the output file of the downloaded file.\n"
+                  << "\t-u URL_ADDRESS\t\tSpecifies the URL of the file to download or the RESTful address.\n"
+                  << "\t-t TYPE\t\t\tSpecifies the type of action to execute [download, post, get, put, delete].\n"
+                  << "\t-p JSON_FILE\t\tSpecifies the file containing the JSON data to send in the POST request.\n"
+                  << "\t-o OUTPUT_FILE\t\tSpecifies the output file of the downloaded file.\n"
+                  << "\t-H HEADERS\t\tSpecifies the headers to send in the request. If not preset, DEFAULT_HEADERS will be used.\n"
+                  << "\t--cacert CACERT\t\tSpecifies the CA certificate file to use in the request.\n"
+                  << "\t--cert CERT\t\tSpecifies the certificate file to use in the request.\n"
+                  << "\t--key KEY\t\tSpecifies the key file to use in the request.\n"
+                  << "\t--username USERNAME\tSpecifies the username to use in the request.\n"
+                  << "\t--password PASSWORD\tSpecifies the password to use in the request.\n"
                   << "\nExample:"
                   << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t download -o out \n"
                   << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get\n"
                   << "\n\t./urlrequester_testtool -u https://httpbin.org/post -t post -p input.json\n"
                   << "\n\t./urlrequester_testtool -u https://httpbin.org/put -t put -p input.json\n"
                   << "\n\t./urlrequester_testtool -u https://httpbin.org/delete -t delete\n"
+                  << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get -H \"Authorization: Bearer token\"\n"
+                  << "\n\t./urlrequester_testtool -u https://httpbin.org/get -t get --cacert cacert.pem --cert cert.pem --key key.pem --username admin --password admin\n"
                   << std::endl;
     }
 
@@ -131,6 +193,12 @@ private:
     const std::string m_outputFile;
     const std::string m_type;
     nlohmann::json m_postData;
+    const std::string m_headers;
+    const std::string m_cacert;
+    const std::string m_cert;
+    const std::string m_key;
+    const std::string m_username;
+    const std::string m_password;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/test_tool/factoryAction.hpp
+++ b/test_tool/factoryAction.hpp
@@ -14,7 +14,6 @@
 
 #include "actions.hpp"
 #include "cmdArgsParser.hpp"
-#include <iostream>
 #include <memory>
 
 /**

--- a/test_tool/factoryAction.hpp
+++ b/test_tool/factoryAction.hpp
@@ -30,29 +30,51 @@ public:
      */
     static std::unique_ptr<IAction> create(const CmdLineArgs& args)
     {
+        std::string caRootCertificate {args.cacert()};
+        std::string sslCertificate {args.cert()};
+        std::string sslKey {args.key()};
+        std::string username {args.username()};
+        std::string password {args.password()};
+
+        auto secureCommunication = SecureCommunication::builder();
+        secureCommunication.basicAuth(username + ":" + password)
+            .sslCertificate(sslCertificate)
+            .sslKey(sslKey)
+            .caRootCertificate(caRootCertificate);
+
+        std::unordered_set<std::string> headers;
+        if (args.headers().empty())
+        {
+            headers = DEFAULT_HEADERS;
+        }
+        else
+        {
+            headers.emplace(args.headers());
+        }
+
         if (0 == args.type().compare("download"))
         {
-            return std::make_unique<DownloadAction>(args.url(), args.outputFile());
+            return std::make_unique<DownloadAction>(args.url(), args.outputFile(), headers, secureCommunication);
         }
         else if (0 == args.type().compare("get"))
         {
-            return std::make_unique<GetAction>(args.url());
+            return std::make_unique<GetAction>(args.url(), headers, secureCommunication);
         }
         else if (0 == args.type().compare("post"))
         {
-            return std::make_unique<PostAction>(args.url(), args.postArguments());
+            return std::make_unique<PostAction>(args.url(), args.postArguments(), headers, secureCommunication);
         }
         else if (0 == args.type().compare("put"))
         {
-            return std::make_unique<PutAction>(args.url(), args.postArguments());
+            return std::make_unique<PutAction>(args.url(), args.postArguments(), headers, secureCommunication);
         }
         else if (0 == args.type().compare("patch"))
         {
-            return std::make_unique<PatchAction>(args.url(), args.postArguments());
+            return std::make_unique<PatchAction>(args.url(), args.postArguments(), headers, secureCommunication);
         }
         else if (0 == args.type().compare("delete"))
         {
-            return std::make_unique<DeleteAction>(args.url());
+            return std::make_unique<DeleteAction>(args.url(), headers, secureCommunication);
         }
         else
         {

--- a/test_tool/main.cpp
+++ b/test_tool/main.cpp
@@ -26,6 +26,7 @@ int main(const int argc, const char* argv[])
     {
         std::cerr << e.what() << std::endl;
         retVal = 1;
+        CmdLineArgs::showHelp();
     }
 
     return retVal;


### PR DESCRIPTION
|Related issue|
|---|
|Closes wazuh/wazuh/issues/22532|

## Description

This PR adds some options to the test tool to properly connect with username/password and CA authentication

```
root@74a36f92d602:/# LD_LIBRARY_PATH=./ ./urlrequest_testtool --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem --username admin --password admin -t get -u https://172.17.0.2:9200
{
  "name" : "node-2",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "1OCvdXmLReGM-_2TpGekow",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "eee49cb340edc6c4d489bcd9324dda571fc8dc03",
    "build_date" : "2023-09-20T23:54:29.889267151Z",
    "build_snapshot" : false,
    "lucene_version" : "9.7.0",
    "minimum_wire_compatibility_version" : "7.10.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}

```

Also, a flag to set different headers than default was included.