### PR TITLE
Add the ability to set the value of the user agent in a request

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -36,6 +36,7 @@ public:
      * @param onError Callback to be called in case of error.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -45,6 +46,7 @@ public:
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::unordered_set<std::string>& httpHeaders = {},
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -57,6 +59,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -68,6 +71,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -80,6 +84,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -91,6 +96,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -102,6 +108,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -112,6 +119,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -124,6 +132,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -135,6 +144,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -147,6 +157,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -158,6 +169,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -171,6 +183,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -182,6 +195,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -195,6 +209,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -206,6 +221,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
@@ -217,6 +233,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -227,6 +244,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 };

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -137,6 +137,7 @@ public:
      * @param onError Callback to be called when an error occurs.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -146,6 +147,7 @@ public:
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::unordered_set<std::string>& httpHeaders = {},
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -158,6 +160,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -169,6 +172,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -181,6 +185,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -192,6 +197,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -203,6 +209,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -213,6 +220,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -225,6 +233,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -236,6 +245,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -248,6 +258,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -259,6 +270,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -272,6 +284,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -283,6 +296,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -296,6 +310,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -307,6 +322,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 
@@ -318,6 +334,7 @@ public:
      * @param fileName File name of output file.
      * @param httpHeaders Headers to be added to the query.
      * @param secureCommunication Secure communication object.
+     * @param userAgent User agent to be used in the request.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
@@ -328,6 +345,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true) = 0;
 };

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -33,13 +33,14 @@ public:
     /**
      * @brief Performs a UNIX SOCKET DOWNLOAD request.
      *
-     * @param url
-     * @param fileName
-     * @param onError
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param fileName File name of output file.
+     * @param onError Callback to be called in case of error.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void download(
         const URL& url,
@@ -47,20 +48,22 @@ public:
         std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET POST request.
      *
-     * @param url
-     * @param data
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param data Data to send (nlohmann::json).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void post(
         const URL& url,
@@ -70,21 +73,23 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 
     /**
      * @brief Performs a UNIX SOCKET POST request.
      *
-     * @param url
-     * @param data
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param data Data to send (string).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void post(
         const URL& url,
@@ -94,19 +99,21 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET GET request.
      *
-     * @param url
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void get(
         const URL& url,
@@ -115,20 +122,22 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET PUT request.
      *
-     * @param url
-     * @param data
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param data Data to send (nlohmann::json).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void put(
         const URL& url,
@@ -138,20 +147,22 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET PUT request.
      *
-     * @param url
-     * @param data
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param data Data to send (string).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void put(
         const URL& url,
@@ -161,20 +172,22 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET PATCH request.
      *
-     * @param url
-     * @param data
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param data Data to send (nlohmann::json).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void patch(
         const URL& url,
@@ -184,20 +197,22 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET PATCH request.
      *
-     * @param url
-     * @param data
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param data Data to send (string).
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void patch(
         const URL& url,
@@ -207,19 +222,21 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET DELETE request.
      *
-     * @param url
-     * @param onSuccess
-     * @param onError
-     * @param fileName
-     * @param httpHeaders
-     * @param secureCommunication
-     * @param handlerType
-     * @param shouldRun
+     * @param url URL to send the request.
+     * @param onSuccess Callback to be called in case of success.
+     * @param onError Callback to be called in case of error.
+     * @param fileName File name of output file.
+     * @param httpHeaders Headers to be added to the query.
+     * @param secureCommunication Object that provides secure communication.
+     * @param userAgent User agent to be used in the request.
+     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
+     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
      */
     void delete_(
         const URL& url,
@@ -228,6 +245,7 @@ public:
         const std::string& fileName = "",
         const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
         const SecureCommunication& secureCommunication = {},
+        const std::string& userAgent = {},
         const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
         const std::atomic<bool>& shouldRun = true);
 };

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -25,6 +25,7 @@ void HTTPRequest::download(const URL& url,
                            std::function<void(const std::string&, const long)> onError,
                            const std::unordered_set<std::string>& httpHeaders,
                            const SecureCommunication& secureCommunication,
+                           const std::string& userAgent,
                            const CurlHandlerTypeEnum& handlerType,
                            const std::atomic<bool>& shouldRun)
 {
@@ -34,6 +35,7 @@ void HTTPRequest::download(const URL& url,
             .url(url.url(), secureCommunication)
             .outputFile(outputFile)
             .appendHeaders(httpHeaders)
+            .userAgent(userAgent)
             .execute();
     }
     catch (const Curl::CurlException& ex)
@@ -53,6 +55,7 @@ void HTTPRequest::post(const URL& url,
                        const std::string& fileName,
                        const std::unordered_set<std::string>& httpHeaders,
                        const SecureCommunication& secureCommunication,
+                       const std::string& userAgent,
                        const CurlHandlerTypeEnum& handlerType,
                        const std::atomic<bool>& shouldRun)
 {
@@ -67,7 +70,7 @@ void HTTPRequest::post(const URL& url,
         return;
     }
 
-    post(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication);
+    post(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication, userAgent);
 }
 
 void HTTPRequest::post(const URL& url,
@@ -77,6 +80,7 @@ void HTTPRequest::post(const URL& url,
                        const std::string& fileName,
                        const std::unordered_set<std::string>& httpHeaders,
                        const SecureCommunication& secureCommunication,
+                       const std::string& userAgent,
                        const CurlHandlerTypeEnum& handlerType,
                        const std::atomic<bool>& shouldRun)
 {
@@ -86,6 +90,7 @@ void HTTPRequest::post(const URL& url,
         req.url(url.url(), secureCommunication)
             .postData(data)
             .appendHeaders(httpHeaders)
+            .userAgent(userAgent)
             .outputFile(fileName)
             .execute();
 
@@ -107,13 +112,18 @@ void HTTPRequest::get(const URL& url,
                       const std::string& fileName,
                       const std::unordered_set<std::string>& httpHeaders,
                       const SecureCommunication& secureCommunication,
+                      const std::string& userAgent,
                       const CurlHandlerTypeEnum& handlerType,
                       const std::atomic<bool>& shouldRun)
 {
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
-        req.url(url.url(), secureCommunication).appendHeaders(httpHeaders).outputFile(fileName).execute();
+        req.url(url.url(), secureCommunication)
+            .appendHeaders(httpHeaders)
+            .userAgent(userAgent)
+            .outputFile(fileName)
+            .execute();
 
         onSuccess(req.response());
     }
@@ -134,6 +144,7 @@ void HTTPRequest::put(const URL& url,
                       const std::string& fileName,
                       const std::unordered_set<std::string>& httpHeaders,
                       const SecureCommunication& secureCommunication,
+                      const std::string& userAgent,
                       const CurlHandlerTypeEnum& handlerType,
                       const std::atomic<bool>& shouldRun)
 {
@@ -148,7 +159,7 @@ void HTTPRequest::put(const URL& url,
         return;
     }
 
-    put(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication);
+    put(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication, userAgent);
 }
 
 void HTTPRequest::put(const URL& url,
@@ -158,6 +169,7 @@ void HTTPRequest::put(const URL& url,
                       const std::string& fileName,
                       const std::unordered_set<std::string>& httpHeaders,
                       const SecureCommunication& secureCommunication,
+                      const std::string& userAgent,
                       const CurlHandlerTypeEnum& handlerType,
                       const std::atomic<bool>& shouldRun)
 {
@@ -167,6 +179,7 @@ void HTTPRequest::put(const URL& url,
         req.url(url.url(), secureCommunication)
             .postData(data)
             .appendHeaders(httpHeaders)
+            .userAgent(userAgent)
             .outputFile(fileName)
             .execute();
 
@@ -189,6 +202,7 @@ void HTTPRequest::patch(const URL& url,
                         const std::string& fileName,
                         const std::unordered_set<std::string>& httpHeaders,
                         const SecureCommunication& secureCommunication,
+                        const std::string& userAgent,
                         const CurlHandlerTypeEnum& handlerType,
                         const std::atomic<bool>& shouldRun)
 {
@@ -202,7 +216,7 @@ void HTTPRequest::patch(const URL& url,
         onError(ex.what(), NOT_USED);
         return;
     }
-    patch(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication);
+    patch(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication, userAgent);
 }
 
 void HTTPRequest::patch(const URL& url,
@@ -212,6 +226,7 @@ void HTTPRequest::patch(const URL& url,
                         const std::string& fileName,
                         const std::unordered_set<std::string>& httpHeaders,
                         const SecureCommunication& secureCommunication,
+                        const std::string& userAgent,
                         const CurlHandlerTypeEnum& handlerType,
                         const std::atomic<bool>& shouldRun)
 {
@@ -221,6 +236,7 @@ void HTTPRequest::patch(const URL& url,
         req.url(url.url(), secureCommunication)
             .postData(data)
             .appendHeaders(httpHeaders)
+            .userAgent(userAgent)
             .outputFile(fileName)
             .execute();
 
@@ -242,13 +258,18 @@ void HTTPRequest::delete_(const URL& url,
                           const std::string& fileName,
                           const std::unordered_set<std::string>& httpHeaders,
                           const SecureCommunication& secureCommunication,
+                          const std::string& userAgent,
                           const CurlHandlerTypeEnum& handlerType,
                           const std::atomic<bool>& shouldRun)
 {
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
-        req.url(url.url(), secureCommunication).appendHeaders(httpHeaders).outputFile(fileName).execute();
+        req.url(url.url(), secureCommunication)
+            .appendHeaders(httpHeaders)
+            .userAgent(userAgent)
+            .outputFile(fileName)
+            .execute();
 
         onSuccess(req.response());
     }

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -23,6 +23,7 @@ void UNIXSocketRequest::download(const URL& url,
                                  std::function<void(const std::string&, const long)> onError,
                                  const std::unordered_set<std::string>& httpHeaders,
                                  const SecureCommunication& secureCommunication,
+                                 const std::string& userAgent,
                                  const CurlHandlerTypeEnum& handlerType,
                                  const std::atomic<bool>& shouldRun)
 {
@@ -31,6 +32,7 @@ void UNIXSocketRequest::download(const URL& url,
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))
             .url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
+            .userAgent(userAgent)
             .outputFile(outputFile)
             .execute();
     }
@@ -51,6 +53,7 @@ void UNIXSocketRequest::post(const URL& url,
                              const std::string& fileName,
                              const std::unordered_set<std::string>& httpHeaders,
                              const SecureCommunication& secureCommunication,
+                             const std::string& userAgent,
                              const CurlHandlerTypeEnum& handlerType,
                              const std::atomic<bool>& shouldRun)
 {
@@ -64,7 +67,7 @@ void UNIXSocketRequest::post(const URL& url,
         onError(ex.what(), NOT_USED);
         return;
     }
-    post(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication);
+    post(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication, userAgent);
 }
 
 void UNIXSocketRequest::post(const URL& url,
@@ -74,6 +77,7 @@ void UNIXSocketRequest::post(const URL& url,
                              const std::string& fileName,
                              const std::unordered_set<std::string>& httpHeaders,
                              const SecureCommunication& secureCommunication,
+                             const std::string& userAgent,
                              const CurlHandlerTypeEnum& handlerType,
                              const std::atomic<bool>& shouldRun)
 {
@@ -82,6 +86,7 @@ void UNIXSocketRequest::post(const URL& url,
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
+            .userAgent(userAgent)
             .postData(data)
             .outputFile(fileName)
             .execute();
@@ -104,13 +109,18 @@ void UNIXSocketRequest::get(const URL& url,
                             const std::string& fileName,
                             const std::unordered_set<std::string>& httpHeaders,
                             const SecureCommunication& secureCommunication,
+                            const std::string& userAgent,
                             const CurlHandlerTypeEnum& handlerType,
                             const std::atomic<bool>& shouldRun)
 {
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
-        req.url(url.url(), secureCommunication).unixSocketPath(url.unixSocketPath()).outputFile(fileName).execute();
+        req.url(url.url(), secureCommunication)
+            .unixSocketPath(url.unixSocketPath())
+            .userAgent(userAgent)
+            .outputFile(fileName)
+            .execute();
 
         onSuccess(req.response());
     }
@@ -131,6 +141,7 @@ void UNIXSocketRequest::put(const URL& url,
                             const std::string& fileName,
                             const std::unordered_set<std::string>& httpHeaders,
                             const SecureCommunication& secureCommunication,
+                            const std::string& userAgent,
                             const CurlHandlerTypeEnum& handlerType,
                             const std::atomic<bool>& shouldRun)
 {
@@ -144,7 +155,7 @@ void UNIXSocketRequest::put(const URL& url,
         onError(ex.what(), NOT_USED);
         return;
     }
-    put(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication);
+    put(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication, userAgent);
 }
 
 void UNIXSocketRequest::put(const URL& url,
@@ -154,6 +165,7 @@ void UNIXSocketRequest::put(const URL& url,
                             const std::string& fileName,
                             const std::unordered_set<std::string>& httpHeaders,
                             const SecureCommunication& secureCommunication,
+                            const std::string& userAgent,
                             const CurlHandlerTypeEnum& handlerType,
                             const std::atomic<bool>& shouldRun)
 {
@@ -162,6 +174,7 @@ void UNIXSocketRequest::put(const URL& url,
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
+            .userAgent(userAgent)
             .postData(data)
             .outputFile(fileName)
             .execute();
@@ -185,6 +198,7 @@ void UNIXSocketRequest::patch(const URL& url,
                               const std::string& fileName,
                               const std::unordered_set<std::string>& httpHeaders,
                               const SecureCommunication& secureCommunication,
+                              const std::string& userAgent,
                               const CurlHandlerTypeEnum& handlerType,
                               const std::atomic<bool>& shouldRun)
 {
@@ -198,7 +212,7 @@ void UNIXSocketRequest::patch(const URL& url,
         onError(ex.what(), NOT_USED);
         return;
     }
-    patch(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication);
+    patch(url, dataStr, std::move(onSuccess), onError, fileName, httpHeaders, secureCommunication, userAgent);
 }
 
 void UNIXSocketRequest::patch(const URL& url,
@@ -208,6 +222,7 @@ void UNIXSocketRequest::patch(const URL& url,
                               const std::string& fileName,
                               const std::unordered_set<std::string>& httpHeaders,
                               const SecureCommunication& secureCommunication,
+                              const std::string& userAgent,
                               const CurlHandlerTypeEnum& handlerType,
                               const std::atomic<bool>& shouldRun)
 {
@@ -216,6 +231,7 @@ void UNIXSocketRequest::patch(const URL& url,
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
+            .userAgent(userAgent)
             .postData(data)
             .outputFile(fileName)
             .execute();
@@ -238,13 +254,18 @@ void UNIXSocketRequest::delete_(const URL& url,
                                 const std::string& fileName,
                                 const std::unordered_set<std::string>& httpHeaders,
                                 const SecureCommunication& secureCommunication,
+                                const std::string& userAgent,
                                 const CurlHandlerTypeEnum& handlerType,
                                 const std::atomic<bool>& shouldRun)
 {
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
-        req.url(url.url(), secureCommunication).unixSocketPath(url.unixSocketPath()).outputFile(fileName).execute();
+        req.url(url.url(), secureCommunication)
+            .unixSocketPath(url.unixSocketPath())
+            .userAgent(userAgent)
+            .outputFile(fileName)
+            .execute();
 
         onSuccess(req.response());
     }

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -181,6 +181,7 @@ static void BM_DownloadUsingTheSingleHandler(benchmark::State& state)
             [&](const std::string& /*result*/, const long /*responseCode*/) {},
             {},
             {},
+            {},
             CurlHandlerTypeEnum::SINGLE);
     }
 }
@@ -199,6 +200,7 @@ static void BM_CustomDownloadUsingTheMultiHandler(benchmark::State& state)
             HttpURL("http://localhost:44441/"),
             "out.txt",
             [&](const std::string& /*result*/, const long /*responseCode*/) {},
+            {},
             {},
             {},
             CurlHandlerTypeEnum::MULTI);

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -155,7 +155,7 @@ TEST_F(ComponentTestInterface, DownloadFileError)
 TEST_F(ComponentTestInterface, DownloadFileUsingTheSingleHandler)
 {
     HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/"), "./test.txt", [](auto, auto) {}, {}, {}, CurlHandlerTypeEnum::SINGLE);
+        HttpURL("http://localhost:44441/"), "./test.txt", [](auto, auto) {}, {}, {}, {}, CurlHandlerTypeEnum::SINGLE);
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -178,6 +178,7 @@ TEST_F(ComponentTestInterface, DownloadFileEmptyURLUsingTheSingleHandler)
 
             m_callbackComplete = true;
         },
+        {},
         {},
         {},
         CurlHandlerTypeEnum::SINGLE);
@@ -205,6 +206,7 @@ TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheSingleHandler)
         },
         {},
         {},
+        {},
         CurlHandlerTypeEnum::SINGLE);
 
     EXPECT_TRUE(m_callbackComplete);
@@ -221,6 +223,7 @@ TEST_F(ComponentTestInterface, DownloadFileUsingTheMultiHandler)
         HttpURL("http://localhost:44441/"),
         "./test.txt",
         [](auto, auto) {},
+        {},
         {},
         {},
         CurlHandlerTypeEnum::MULTI,
@@ -243,6 +246,7 @@ TEST_F(ComponentTestInterface, InterruptMultiHandler)
         HttpURL("http://localhost:44441/"),
         "./test.txt",
         [](auto, auto) {},
+        {},
         {},
         {},
         CurlHandlerTypeEnum::MULTI,
@@ -275,6 +279,7 @@ TEST_F(ComponentTestInterface, InterruptDownload)
                 [](auto, auto) {},
                 {},
                 {},
+                {},
                 CurlHandlerTypeEnum::MULTI,
                 shouldRun);
         });
@@ -286,6 +291,7 @@ TEST_F(ComponentTestInterface, InterruptDownload)
                 HttpURL("http://localhost:44441/sleep/" + sleepSecondHandler),
                 "./test2.txt",
                 [](auto, auto) {},
+                {},
                 {},
                 {},
                 CurlHandlerTypeEnum::MULTI,
@@ -330,6 +336,7 @@ TEST_F(ComponentTestInterface, DownloadFileEmptyURLUsingTheMultiHandler)
         },
         {},
         {},
+        {},
         CurlHandlerTypeEnum::MULTI,
         shouldRun);
 
@@ -356,6 +363,7 @@ TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheMultiHandler)
 
             m_callbackComplete = true;
         },
+        {},
         {},
         {},
         CurlHandlerTypeEnum::MULTI,

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -910,3 +910,122 @@ TEST_F(ComponentTestInterface, PatchSimpleFunctionality)
 
     EXPECT_TRUE(m_callbackComplete);
 }
+
+/**
+ * @brief Test the DOWNLOAD request setting a custom user-agent.
+ */
+TEST_F(ComponentTestInterface, DownloadWithCustomUserAgent)
+{
+    const std::string userAgent {"Custom-User-Agent"};
+
+    HTTPRequest::instance().download(
+        HttpURL("http://localhost:44441/"), "./test.txt", [](auto, auto) {}, DEFAULT_HEADERS, {}, userAgent);
+
+    std::ifstream file("./test.txt");
+    std::string line;
+    std::getline(file, line);
+    EXPECT_EQ(line, "Hello World!");
+}
+
+/**
+ * @brief Test the POST request setting a custom user-agent.
+ */
+TEST_F(ComponentTestInterface, PostWithCustomUserAgent)
+{
+    const std::string userAgent {"Custom-User-Agent"};
+
+    HTTPRequest::instance().post(
+        HttpURL("http://localhost:44441/"),
+        R"({"hello":"world"})"_json,
+        [&](const std::string& /*response*/) { m_callbackComplete = true; },
+        [](auto, auto) {},
+        "",
+        DEFAULT_HEADERS,
+        {},
+        userAgent);
+
+    EXPECT_TRUE(m_callbackComplete);
+}
+
+/**
+ * @brief Test the GET request setting a custom user-agent.
+ *
+ */
+TEST_F(ComponentTestInterface, GetWithCustomUserAgent)
+{
+    const std::string userAgent {"Custom-User-Agent"};
+
+    HTTPRequest::instance().get(
+        HttpURL("http://localhost:44441/"),
+        [&](const std::string& /*response*/) { m_callbackComplete = true; },
+        [](auto, auto) {},
+        "",
+        DEFAULT_HEADERS,
+        {},
+        userAgent);
+
+    EXPECT_TRUE(m_callbackComplete);
+}
+
+/**
+ * @brief Test the PUT request setting a custom user-agent.
+ *
+ */
+TEST_F(ComponentTestInterface, PutWithCustomUserAgent)
+{
+    const std::string userAgent {"Custom-User-Agent"};
+
+    HTTPRequest::instance().put(
+        HttpURL("http://localhost:44441/"),
+        R"({"hello":"world"})"_json,
+        [&](const std::string& /*response*/) { m_callbackComplete = true; },
+        [](auto, auto) {},
+        "",
+        DEFAULT_HEADERS,
+        {},
+        userAgent);
+
+    EXPECT_TRUE(m_callbackComplete);
+}
+
+/**
+ * @brief Test the PATCH request setting a custom user-agent.
+ *
+ */
+TEST_F(ComponentTestInterface, PatchWithCustomUserAgent)
+{
+    const std::string userAgent {"Custom-User-Agent"};
+
+    HTTPRequest::instance().patch(
+        HttpURL("http://localhost:44441/"),
+        R"({"hello":"world"})"_json,
+        [&](const std::string& /*response*/) { m_callbackComplete = true; },
+        [](auto, auto) {},
+        "",
+        DEFAULT_HEADERS,
+        {},
+        userAgent);
+
+    EXPECT_TRUE(m_callbackComplete);
+}
+
+/**
+ * @brief Test the DELETE request setting a custom user-agent.
+ *
+ */
+TEST_F(ComponentTestInterface, DeleteWithCustomUserAgent)
+{
+    const std::string userAgent {"Custom-User-Agent"};
+    auto random {std::to_string(std::rand())};
+
+    HTTPRequest::instance().delete_(
+        HttpURL("http://localhost:44441/" + random),
+        [&](const std::string& /*response*/) { m_callbackComplete = true; },
+        [](auto, auto) {},
+        "",
+        DEFAULT_HEADERS,
+        {},
+        userAgent);
+
+    EXPECT_TRUE(m_callbackComplete);
+}


### PR DESCRIPTION
| Issue |
| --- |
|Closes #56 |

## Description

This PR add the ability to set the value of the user agent in a request.

## Test
RTR
```
damangold@damangold:~/Wazuh/dev/wazuh-http-request$ ./rtr 
Running RTR on /home/damangold/Wazuh/dev/wazuh-http-request
->Step: Coding style
CLANG-FORMAT: successful
->Step: Cppcheck
CPPCHECK: successful
->Step: Build
BUILDING: successful
->Step: Unit tests
TESTING: successful
->Step: Doxygen
DOXYGEN GENERATION: successful
RTR results on /tmp/wazuh-rtr-54b891 directory.

```