### PR TITLE
Refactor: Improve parameters interface 

### DIFF
--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -31,222 +31,69 @@ class HTTPRequest final
 public:
     /**
      * @brief Performs a HTTP DOWNLOAD request.
-     * @param url URL to send the request.
-     * @param fileName Output file.
-     * @param onError Callback to be called in case of error.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     *
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void download(
-        const URL& url,
-        const std::string& fileName,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::unordered_set<std::string>& httpHeaders = {},
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void download(RequestParameters requestParameters,
+                  PostRequestParameters postRequestParameters = {},
+                  ConfigurationParameters configurationParameters = {});
 
     /**
      * @brief Performs a HTTP POST request.
-     * @param url URL to send the request.
-     * @param data Data to send (nlohmann::json).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     *
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void post(
-        const URL& url,
-        const nlohmann::json& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
-
-    /**
-     * @brief Performs a HTTP POST request.
-     * @param url URL to send the request.
-     * @param data Data to send (string).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
-     */
-    void post(
-        const URL& url,
-        const std::string& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void post(RequestParameters requestParameters,
+              PostRequestParameters postRequestParameters = {},
+              ConfigurationParameters configurationParameters = {});
 
     /**
      * @brief Performs a HTTP GET request.
-     * @param url URL to send the request.
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     *
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void get(
-        const URL& url,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void get(RequestParameters requestParameters,
+             PostRequestParameters postRequestParameters = {},
+             ConfigurationParameters configurationParameters = {});
 
     /**
      * @brief Performs a HTTP UPDATE request.
-     * @param url URL to send the request.
-     * @param data Data to send (nlohmann::json).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     *
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void put(
-        const URL& url,
-        const nlohmann::json& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
-
-    /**
-     * @brief Performs a HTTP UPDATE request.
-     * @param url URL to send the request.
-     * @param data Data to send (std::string).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
-     */
-    void put(
-        const URL& url,
-        const std::string& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void put(RequestParameters requestParameters,
+             PostRequestParameters postRequestParameters = {},
+             ConfigurationParameters configurationParameters = {});
 
     /**
      * @brief Performs an HTTP PATCH request.
      *
-     * @param url URL to send the request.
-     * @param data Data to send (nlohmann::json).
-     * @param onSuccess Callback to be called when the request is successful.
-     * @param onError Callback to be called when an error occurs.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void patch(
-        const URL& url,
-        const nlohmann::json& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
-
-    /**
-     * @brief Performs an HTTP PATCH request.
-     *
-     * @param url URL to send the request.
-     * @param data Data to send (std::string).
-     * @param onSuccess Callback to be called when the request is successful.
-     * @param onError Callback to be called when an error occurs.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
-     */
-    void patch(
-        const URL& url,
-        const std::string& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void patch(RequestParameters requestParameters,
+               PostRequestParameters postRequestParameters = {},
+               ConfigurationParameters configurationParameters = {});
 
     /**
      * @brief Performs a HTTP DELETE request.
-     * @param url URL to send the request.
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Secure communication object.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     *
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void delete_(
-        const URL& url,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void delete_(RequestParameters requestParameters,
+                 PostRequestParameters postRequestParameters = {},
+                 ConfigurationParameters configurationParameters = {});
 };
 
 #endif // _HTTP_REQUEST_HPP

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -124,53 +124,90 @@ public:
 };
 
 /**
+ * @struct RequestParameters
  * @brief The structure groups all the parameters required for the request, like the URL, the data to be sent, the
  * headers, etc. They can be thought of as "what" to do.
- *
- * @param url URL to send the request.
- * @param data Data to send (string or nlohmann::json).
- * @param secureCommunication Secure communication object.
- * @param httpHeaders Headers to be added to the query.
  */
 
 struct RequestParameters
 {
+    /**
+     * @brief URL to send the request.
+     *
+     */
     const URL& url;
+
+    /**
+     * @brief Data to send (string or nlohmann::json).
+     *
+     */
     const std::variant<std::string, nlohmann::json> data = {};
+
+    /**
+     * @brief Secure communication object.
+     *
+     */
     const SecureCommunication& secureCommunication = {};
+
+    /**
+     * @brief Headers to be added to the query.
+     *
+     */
     const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS;
 };
 
 /**
+ * @struct ConfigurationParameters
  * @brief The structure groups all the parameters that modify the behavior of the request, like the timeout, library
  * parameters configuration, etc; and everything that changes the way the request is performed.
  * They can be thought of as "how" to do.
- *
- * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
- * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
- * @param userAgent User agent to be used in the request.
  */
 struct ConfigurationParameters
 {
+    /**
+     * @brief Type of the cURL handler. Default is 'SINGLE'.
+     *
+     */
     const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE;
+
+    /**
+     * @brief Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     *
+     */
     const std::atomic<bool>& shouldRun = true;
+
+    /**
+     * @brief User agent to be used in the request.
+     *
+     */
     const std::string& userAgent = {};
 };
 
 /**
+ * @struct PostRequestParameters
  * @brief The structure groups all the parameters related to the actions to be performed after the request is made, like
  * error handling, results processing, etc. They can be thought of as "what to do after".
- *
- * @param onSuccess Callback to be called when the request is successful.
- * @param onError Callback to be called when an error occurs.
- * @param outputFile File name of to store the output data.
  */
 struct PostRequestParameters
 {
+    /**
+     * @brief Callback to be called when the request is successful.
+     *
+     */
     std::function<void(const std::string&)> onSuccess = [](auto) {
     };
+
+    /**
+     * @brief Callback to be called when an error occurs.
+     *
+     */
     std::function<void(const std::string&, const long)> onError = [](auto, auto) {
     };
+
+    /**
+     * @brief File name of to store the output data.
+     *
+     */
     const std::string& outputFile = "";
 };
 

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -33,221 +33,66 @@ public:
     /**
      * @brief Performs a UNIX SOCKET DOWNLOAD request.
      *
-     * @param url URL to send the request.
-     * @param fileName File name of output file.
-     * @param onError Callback to be called in case of error.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void download(
-        const URL& url,
-        const std::string& fileName,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void download(RequestParameters requestParameters,
+                  PostRequestParameters postRequestParameters,
+                  ConfigurationParameters configurationParameters);
     /**
      * @brief Performs a UNIX SOCKET POST request.
      *
-     * @param url URL to send the request.
-     * @param data Data to send (nlohmann::json).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void post(
-        const URL& url,
-        const nlohmann::json& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void post(RequestParameters requestParameters,
+              PostRequestParameters postRequestParameters,
+              ConfigurationParameters configurationParameters);
 
-    /**
-     * @brief Performs a UNIX SOCKET POST request.
-     *
-     * @param url URL to send the request.
-     * @param data Data to send (string).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
-     */
-    void post(
-        const URL& url,
-        const std::string& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
     /**
      * @brief Performs a UNIX SOCKET GET request.
      *
-     * @param url URL to send the request.
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void get(
-        const URL& url,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void get(RequestParameters requestParameters,
+             PostRequestParameters postRequestParameters,
+             ConfigurationParameters configurationParameters);
     /**
      * @brief Performs a UNIX SOCKET PUT request.
      *
-     * @param url URL to send the request.
-     * @param data Data to send (nlohmann::json).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void put(
-        const URL& url,
-        const nlohmann::json& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
-    /**
-     * @brief Performs a UNIX SOCKET PUT request.
-     *
-     * @param url URL to send the request.
-     * @param data Data to send (string).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
-     */
-    void put(
-        const URL& url,
-        const std::string& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void put(RequestParameters requestParameters,
+             PostRequestParameters postRequestParameters,
+             ConfigurationParameters configurationParameters);
+
     /**
      * @brief Performs a UNIX SOCKET PATCH request.
      *
-     * @param url URL to send the request.
-     * @param data Data to send (nlohmann::json).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request..
      */
-    void patch(
-        const URL& url,
-        const nlohmann::json& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
-    /**
-     * @brief Performs a UNIX SOCKET PATCH request.
-     *
-     * @param url URL to send the request.
-     * @param data Data to send (string).
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
-     */
-    void patch(
-        const URL& url,
-        const std::string& data,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void patch(RequestParameters requestParameters,
+               PostRequestParameters postRequestParameters,
+               ConfigurationParameters configurationParameters);
+
     /**
      * @brief Performs a UNIX SOCKET DELETE request.
      *
-     * @param url URL to send the request.
-     * @param onSuccess Callback to be called in case of success.
-     * @param onError Callback to be called in case of error.
-     * @param fileName File name of output file.
-     * @param httpHeaders Headers to be added to the query.
-     * @param secureCommunication Object that provides secure communication.
-     * @param userAgent User agent to be used in the request.
-     * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
-     * @param shouldRun Flag used to interrupt the handler when the 'handlerType' is set to 'MULTI'.
+     * @param requestParameters Parameters to be used in the request. Mandatory.
+     * @param postRequestParameters Parameters that define the behavior after the request is made.
+     * @param configurationParameters Parameters to configure the behavior of the request.
      */
-    void delete_(
-        const URL& url,
-        std::function<void(const std::string&)> onSuccess,
-        std::function<void(const std::string&, const long)> onError = [](auto, auto) {},
-        const std::string& fileName = "",
-        const std::unordered_set<std::string>& httpHeaders = DEFAULT_HEADERS,
-        const SecureCommunication& secureCommunication = {},
-        const std::string& userAgent = {},
-        const CurlHandlerTypeEnum& handlerType = CurlHandlerTypeEnum::SINGLE,
-        const std::atomic<bool>& shouldRun = true);
+    void delete_(RequestParameters requestParameters,
+                 PostRequestParameters postRequestParameters,
+                 ConfigurationParameters configurationParameters);
 };
 
 #endif // _UNIX_SOCKET_REQUEST_HPP

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -61,7 +61,6 @@ void HTTPRequest::post(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters
@@ -75,9 +74,9 @@ void HTTPRequest::post(RequestParameters requestParameters,
 
     try
     {
-        data = std::holds_alternative<std::string>(requestParameters.data)
-                   ? std::get<std::string>(requestParameters.data)
-                   : std::get<nlohmann::json>(requestParameters.data).dump();
+        std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                               ? std::get<std::string>(requestParameters.data)
+                               : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -143,7 +142,6 @@ void HTTPRequest::put(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters
@@ -157,9 +155,9 @@ void HTTPRequest::put(RequestParameters requestParameters,
 
     try
     {
-        data = std::holds_alternative<std::string>(requestParameters.data)
-                   ? std::get<std::string>(requestParameters.data)
-                   : std::get<nlohmann::json>(requestParameters.data).dump();
+        std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                               ? std::get<std::string>(requestParameters.data)
+                               : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -187,7 +185,6 @@ void HTTPRequest::patch(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters
@@ -201,9 +198,9 @@ void HTTPRequest::patch(RequestParameters requestParameters,
 
     try
     {
-        data = std::holds_alternative<std::string>(requestParameters.data)
-                   ? std::get<std::string>(requestParameters.data)
-                   : std::get<nlohmann::json>(requestParameters.data).dump();
+        std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                               ? std::get<std::string>(requestParameters.data)
+                               : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -20,15 +20,22 @@
 
 using wrapperType = cURLWrapper;
 
-void HTTPRequest::download(const URL& url,
-                           const std::string& outputFile,
-                           std::function<void(const std::string&, const long)> onError,
-                           const std::unordered_set<std::string>& httpHeaders,
-                           const SecureCommunication& secureCommunication,
-                           const std::string& userAgent,
-                           const CurlHandlerTypeEnum& handlerType,
-                           const std::atomic<bool>& shouldRun)
+void HTTPRequest::download(RequestParameters requestParameters,
+                           PostRequestParameters postRequestParameters,
+                           ConfigurationParameters configurationParameters)
 {
+    // Request parameters
+    const auto& url {requestParameters.url};
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))
@@ -48,50 +55,36 @@ void HTTPRequest::download(const URL& url,
     }
 }
 
-void HTTPRequest::post(const URL& url,
-                       const nlohmann::json& data,
-                       std::function<void(const std::string&)> onSuccess,
-                       std::function<void(const std::string&, const long)> onError,
-                       const std::string& fileName,
-                       const std::unordered_set<std::string>& httpHeaders,
-                       const SecureCommunication& secureCommunication,
-                       const std::string& userAgent,
-                       const CurlHandlerTypeEnum& handlerType,
-                       const std::atomic<bool>& shouldRun)
+void HTTPRequest::post(RequestParameters requestParameters,
+                       PostRequestParameters postRequestParameters,
+                       ConfigurationParameters configurationParameters)
 {
-    std::string dataStr;
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
-        dataStr = data.dump();
-    }
-    catch (const std::exception& ex)
-    {
-        onError(ex.what(), NOT_USED);
-        return;
-    }
+        data = std::holds_alternative<std::string>(requestParameters.data)
+                   ? std::get<std::string>(requestParameters.data)
+                   : std::get<nlohmann::json>(requestParameters.data).dump();
 
-    post(url, dataStr, std::move(onSuccess), std::move(onError), fileName, httpHeaders, secureCommunication, userAgent);
-}
-
-void HTTPRequest::post(const URL& url,
-                       const std::string& data,
-                       std::function<void(const std::string&)> onSuccess,
-                       std::function<void(const std::string&, const long)> onError,
-                       const std::string& fileName,
-                       const std::unordered_set<std::string>& httpHeaders,
-                       const SecureCommunication& secureCommunication,
-                       const std::string& userAgent,
-                       const CurlHandlerTypeEnum& handlerType,
-                       const std::atomic<bool>& shouldRun)
-{
-    try
-    {
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .postData(data)
             .appendHeaders(httpHeaders)
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -106,23 +99,30 @@ void HTTPRequest::post(const URL& url,
     }
 }
 
-void HTTPRequest::get(const URL& url,
-                      std::function<void(const std::string&)> onSuccess,
-                      std::function<void(const std::string&, const long)> onError,
-                      const std::string& fileName,
-                      const std::unordered_set<std::string>& httpHeaders,
-                      const SecureCommunication& secureCommunication,
-                      const std::string& userAgent,
-                      const CurlHandlerTypeEnum& handlerType,
-                      const std::atomic<bool>& shouldRun)
+void HTTPRequest::get(RequestParameters requestParameters,
+                      PostRequestParameters postRequestParameters,
+                      ConfigurationParameters configurationParameters)
 {
+    // Request parameters
+    const auto& url {requestParameters.url};
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .appendHeaders(httpHeaders)
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -137,50 +137,36 @@ void HTTPRequest::get(const URL& url,
     }
 }
 
-void HTTPRequest::put(const URL& url,
-                      const nlohmann::json& data,
-                      std::function<void(const std::string&)> onSuccess,
-                      std::function<void(const std::string&, const long)> onError,
-                      const std::string& fileName,
-                      const std::unordered_set<std::string>& httpHeaders,
-                      const SecureCommunication& secureCommunication,
-                      const std::string& userAgent,
-                      const CurlHandlerTypeEnum& handlerType,
-                      const std::atomic<bool>& shouldRun)
+void HTTPRequest::put(RequestParameters requestParameters,
+                      PostRequestParameters postRequestParameters,
+                      ConfigurationParameters configurationParameters)
 {
-    std::string dataStr;
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
-        dataStr = data.dump();
-    }
-    catch (const std::exception& ex)
-    {
-        onError(ex.what(), NOT_USED);
-        return;
-    }
+        data = std::holds_alternative<std::string>(requestParameters.data)
+                   ? std::get<std::string>(requestParameters.data)
+                   : std::get<nlohmann::json>(requestParameters.data).dump();
 
-    put(url, dataStr, std::move(onSuccess), std::move(onError), fileName, httpHeaders, secureCommunication, userAgent);
-}
-
-void HTTPRequest::put(const URL& url,
-                      const std::string& data,
-                      std::function<void(const std::string&)> onSuccess,
-                      std::function<void(const std::string&, const long)> onError,
-                      const std::string& fileName,
-                      const std::unordered_set<std::string>& httpHeaders,
-                      const SecureCommunication& secureCommunication,
-                      const std::string& userAgent,
-                      const CurlHandlerTypeEnum& handlerType,
-                      const std::atomic<bool>& shouldRun)
-{
-    try
-    {
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .postData(data)
             .appendHeaders(httpHeaders)
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -195,50 +181,36 @@ void HTTPRequest::put(const URL& url,
     }
 }
 
-void HTTPRequest::patch(const URL& url,
-                        const nlohmann::json& data,
-                        std::function<void(const std::string&)> onSuccess,
-                        std::function<void(const std::string&, const long)> onError,
-                        const std::string& fileName,
-                        const std::unordered_set<std::string>& httpHeaders,
-                        const SecureCommunication& secureCommunication,
-                        const std::string& userAgent,
-                        const CurlHandlerTypeEnum& handlerType,
-                        const std::atomic<bool>& shouldRun)
+void HTTPRequest::patch(RequestParameters requestParameters,
+                        PostRequestParameters postRequestParameters,
+                        ConfigurationParameters configurationParameters)
 {
-    std::string dataStr;
-    try
-    {
-        dataStr = data.dump();
-    }
-    catch (const std::exception& ex)
-    {
-        onError(ex.what(), NOT_USED);
-        return;
-    }
-    patch(
-        url, dataStr, std::move(onSuccess), std::move(onError), fileName, httpHeaders, secureCommunication, userAgent);
-}
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
 
-void HTTPRequest::patch(const URL& url,
-                        const std::string& data,
-                        std::function<void(const std::string&)> onSuccess,
-                        std::function<void(const std::string&, const long)> onError,
-                        const std::string& fileName,
-                        const std::unordered_set<std::string>& httpHeaders,
-                        const SecureCommunication& secureCommunication,
-                        const std::string& userAgent,
-                        const CurlHandlerTypeEnum& handlerType,
-                        const std::atomic<bool>& shouldRun)
-{
     try
     {
+        data = std::holds_alternative<std::string>(requestParameters.data)
+                   ? std::get<std::string>(requestParameters.data)
+                   : std::get<nlohmann::json>(requestParameters.data).dump();
+
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .postData(data)
             .appendHeaders(httpHeaders)
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -253,23 +225,28 @@ void HTTPRequest::patch(const URL& url,
     }
 }
 
-void HTTPRequest::delete_(const URL& url,
-                          std::function<void(const std::string&)> onSuccess,
-                          std::function<void(const std::string&, const long)> onError,
-                          const std::string& fileName,
-                          const std::unordered_set<std::string>& httpHeaders,
-                          const SecureCommunication& secureCommunication,
-                          const std::string& userAgent,
-                          const CurlHandlerTypeEnum& handlerType,
-                          const std::atomic<bool>& shouldRun)
+void HTTPRequest::delete_(RequestParameters requestParameters,
+                          PostRequestParameters postRequestParameters,
+                          ConfigurationParameters configurationParameters)
 {
+    // Request parameters
+    const auto& url {requestParameters.url};
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
         req.url(url.url(), secureCommunication)
             .appendHeaders(httpHeaders)
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -74,9 +74,9 @@ void HTTPRequest::post(RequestParameters requestParameters,
 
     try
     {
-        std::string data = std::holds_alternative<std::string>(requestParameters.data)
-                               ? std::get<std::string>(requestParameters.data)
-                               : std::get<nlohmann::json>(requestParameters.data).dump();
+        const std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                                     ? std::get<std::string>(requestParameters.data)
+                                     : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -155,9 +155,9 @@ void HTTPRequest::put(RequestParameters requestParameters,
 
     try
     {
-        std::string data = std::holds_alternative<std::string>(requestParameters.data)
-                               ? std::get<std::string>(requestParameters.data)
-                               : std::get<nlohmann::json>(requestParameters.data).dump();
+        const std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                                     ? std::get<std::string>(requestParameters.data)
+                                     : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -198,9 +198,9 @@ void HTTPRequest::patch(RequestParameters requestParameters,
 
     try
     {
-        std::string data = std::holds_alternative<std::string>(requestParameters.data)
-                               ? std::get<std::string>(requestParameters.data)
-                               : std::get<nlohmann::json>(requestParameters.data).dump();
+        const std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                                     ? std::get<std::string>(requestParameters.data)
+                                     : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -60,7 +60,6 @@ void UNIXSocketRequest::post(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters
@@ -74,9 +73,9 @@ void UNIXSocketRequest::post(RequestParameters requestParameters,
 
     try
     {
-        data = std::holds_alternative<std::string>(requestParameters.data)
-                   ? std::get<std::string>(requestParameters.data)
-                   : std::get<nlohmann::json>(requestParameters.data).dump();
+        std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                               ? std::get<std::string>(requestParameters.data)
+                               : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -142,7 +141,6 @@ void UNIXSocketRequest::put(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters
@@ -156,9 +154,9 @@ void UNIXSocketRequest::put(RequestParameters requestParameters,
 
     try
     {
-        data = std::holds_alternative<std::string>(requestParameters.data)
-                   ? std::get<std::string>(requestParameters.data)
-                   : std::get<nlohmann::json>(requestParameters.data).dump();
+        std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                               ? std::get<std::string>(requestParameters.data)
+                               : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -186,7 +184,6 @@ void UNIXSocketRequest::patch(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters
@@ -200,9 +197,9 @@ void UNIXSocketRequest::patch(RequestParameters requestParameters,
 
     try
     {
-        data = std::holds_alternative<std::string>(requestParameters.data)
-                   ? std::get<std::string>(requestParameters.data)
-                   : std::get<nlohmann::json>(requestParameters.data).dump();
+        std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                               ? std::get<std::string>(requestParameters.data)
+                               : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -73,9 +73,9 @@ void UNIXSocketRequest::post(RequestParameters requestParameters,
 
     try
     {
-        std::string data = std::holds_alternative<std::string>(requestParameters.data)
-                               ? std::get<std::string>(requestParameters.data)
-                               : std::get<nlohmann::json>(requestParameters.data).dump();
+        const std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                                     ? std::get<std::string>(requestParameters.data)
+                                     : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -154,9 +154,9 @@ void UNIXSocketRequest::put(RequestParameters requestParameters,
 
     try
     {
-        std::string data = std::holds_alternative<std::string>(requestParameters.data)
-                               ? std::get<std::string>(requestParameters.data)
-                               : std::get<nlohmann::json>(requestParameters.data).dump();
+        const std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                                     ? std::get<std::string>(requestParameters.data)
+                                     : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -197,9 +197,9 @@ void UNIXSocketRequest::patch(RequestParameters requestParameters,
 
     try
     {
-        std::string data = std::holds_alternative<std::string>(requestParameters.data)
-                               ? std::get<std::string>(requestParameters.data)
-                               : std::get<nlohmann::json>(requestParameters.data).dump();
+        const std::string data = std::holds_alternative<std::string>(requestParameters.data)
+                                     ? std::get<std::string>(requestParameters.data)
+                                     : std::get<nlohmann::json>(requestParameters.data).dump();
 
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
@@ -227,7 +227,6 @@ void UNIXSocketRequest::delete_(RequestParameters requestParameters,
 {
     // Request parameters
     const auto& url {requestParameters.url};
-    std::string data;
     const auto& secureCommunication {requestParameters.secureCommunication};
     const auto& httpHeaders {requestParameters.httpHeaders};
     // Post request parameters

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -18,15 +18,23 @@
 
 using wrapperType = cURLWrapper;
 
-void UNIXSocketRequest::download(const URL& url,
-                                 const std::string& outputFile,
-                                 std::function<void(const std::string&, const long)> onError,
-                                 const std::unordered_set<std::string>& httpHeaders,
-                                 const SecureCommunication& secureCommunication,
-                                 const std::string& userAgent,
-                                 const CurlHandlerTypeEnum& handlerType,
-                                 const std::atomic<bool>& shouldRun)
+void UNIXSocketRequest::download(RequestParameters requestParameters,
+                                 PostRequestParameters postRequestParameters = {},
+                                 ConfigurationParameters configurationParameters = {})
 {
+    // Request parameters
+    const auto& url {requestParameters.url};
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
         GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))
@@ -46,49 +54,36 @@ void UNIXSocketRequest::download(const URL& url,
     }
 }
 
-void UNIXSocketRequest::post(const URL& url,
-                             const nlohmann::json& data,
-                             std::function<void(const std::string&)> onSuccess,
-                             std::function<void(const std::string&, const long)> onError,
-                             const std::string& fileName,
-                             const std::unordered_set<std::string>& httpHeaders,
-                             const SecureCommunication& secureCommunication,
-                             const std::string& userAgent,
-                             const CurlHandlerTypeEnum& handlerType,
-                             const std::atomic<bool>& shouldRun)
+void UNIXSocketRequest::post(RequestParameters requestParameters,
+                             PostRequestParameters postRequestParameters = {},
+                             ConfigurationParameters configurationParameters = {})
 {
-    std::string dataStr;
-    try
-    {
-        dataStr = data.dump();
-    }
-    catch (const std::exception& ex)
-    {
-        onError(ex.what(), NOT_USED);
-        return;
-    }
-    post(url, dataStr, std::move(onSuccess), std::move(onError), fileName, httpHeaders, secureCommunication, userAgent);
-}
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
 
-void UNIXSocketRequest::post(const URL& url,
-                             const std::string& data,
-                             std::function<void(const std::string&)> onSuccess,
-                             std::function<void(const std::string&, const long)> onError,
-                             const std::string& fileName,
-                             const std::unordered_set<std::string>& httpHeaders,
-                             const SecureCommunication& secureCommunication,
-                             const std::string& userAgent,
-                             const CurlHandlerTypeEnum& handlerType,
-                             const std::atomic<bool>& shouldRun)
-{
     try
     {
+        data = std::holds_alternative<std::string>(requestParameters.data)
+                   ? std::get<std::string>(requestParameters.data)
+                   : std::get<nlohmann::json>(requestParameters.data).dump();
+
         auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
             .userAgent(userAgent)
             .postData(data)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -103,23 +98,30 @@ void UNIXSocketRequest::post(const URL& url,
     }
 }
 
-void UNIXSocketRequest::get(const URL& url,
-                            std::function<void(const std::string&)> onSuccess,
-                            std::function<void(const std::string&, const long)> onError,
-                            const std::string& fileName,
-                            const std::unordered_set<std::string>& httpHeaders,
-                            const SecureCommunication& secureCommunication,
-                            const std::string& userAgent,
-                            const CurlHandlerTypeEnum& handlerType,
-                            const std::atomic<bool>& shouldRun)
+void UNIXSocketRequest::get(RequestParameters requestParameters,
+                            PostRequestParameters postRequestParameters = {},
+                            ConfigurationParameters configurationParameters = {})
 {
+    // Request parameters
+    const auto& url {requestParameters.url};
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
         auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -134,49 +136,36 @@ void UNIXSocketRequest::get(const URL& url,
     }
 }
 
-void UNIXSocketRequest::put(const URL& url,
-                            const nlohmann::json& data,
-                            std::function<void(const std::string&)> onSuccess,
-                            std::function<void(const std::string&, const long)> onError,
-                            const std::string& fileName,
-                            const std::unordered_set<std::string>& httpHeaders,
-                            const SecureCommunication& secureCommunication,
-                            const std::string& userAgent,
-                            const CurlHandlerTypeEnum& handlerType,
-                            const std::atomic<bool>& shouldRun)
+void UNIXSocketRequest::put(RequestParameters requestParameters,
+                            PostRequestParameters postRequestParameters = {},
+                            ConfigurationParameters configurationParameters = {})
 {
-    std::string dataStr;
-    try
-    {
-        dataStr = data.dump();
-    }
-    catch (const std::exception& ex)
-    {
-        onError(ex.what(), NOT_USED);
-        return;
-    }
-    put(url, dataStr, std::move(onSuccess), std::move(onError), fileName, httpHeaders, secureCommunication, userAgent);
-}
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
 
-void UNIXSocketRequest::put(const URL& url,
-                            const std::string& data,
-                            std::function<void(const std::string&)> onSuccess,
-                            std::function<void(const std::string&, const long)> onError,
-                            const std::string& fileName,
-                            const std::unordered_set<std::string>& httpHeaders,
-                            const SecureCommunication& secureCommunication,
-                            const std::string& userAgent,
-                            const CurlHandlerTypeEnum& handlerType,
-                            const std::atomic<bool>& shouldRun)
-{
     try
     {
+        data = std::holds_alternative<std::string>(requestParameters.data)
+                   ? std::get<std::string>(requestParameters.data)
+                   : std::get<nlohmann::json>(requestParameters.data).dump();
+
         auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
             .userAgent(userAgent)
             .postData(data)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -191,50 +180,36 @@ void UNIXSocketRequest::put(const URL& url,
     }
 }
 
-void UNIXSocketRequest::patch(const URL& url,
-                              const nlohmann::json& data,
-                              std::function<void(const std::string&)> onSuccess,
-                              std::function<void(const std::string&, const long)> onError,
-                              const std::string& fileName,
-                              const std::unordered_set<std::string>& httpHeaders,
-                              const SecureCommunication& secureCommunication,
-                              const std::string& userAgent,
-                              const CurlHandlerTypeEnum& handlerType,
-                              const std::atomic<bool>& shouldRun)
+void UNIXSocketRequest::patch(RequestParameters requestParameters,
+                              PostRequestParameters postRequestParameters = {},
+                              ConfigurationParameters configurationParameters = {})
 {
-    std::string dataStr;
-    try
-    {
-        dataStr = data.dump();
-    }
-    catch (const std::exception& ex)
-    {
-        onError(ex.what(), NOT_USED);
-        return;
-    }
-    patch(
-        url, dataStr, std::move(onSuccess), std::move(onError), fileName, httpHeaders, secureCommunication, userAgent);
-}
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
 
-void UNIXSocketRequest::patch(const URL& url,
-                              const std::string& data,
-                              std::function<void(const std::string&)> onSuccess,
-                              std::function<void(const std::string&, const long)> onError,
-                              const std::string& fileName,
-                              const std::unordered_set<std::string>& httpHeaders,
-                              const SecureCommunication& secureCommunication,
-                              const std::string& userAgent,
-                              const CurlHandlerTypeEnum& handlerType,
-                              const std::atomic<bool>& shouldRun)
-{
     try
     {
+        data = std::holds_alternative<std::string>(requestParameters.data)
+                   ? std::get<std::string>(requestParameters.data)
+                   : std::get<nlohmann::json>(requestParameters.data).dump();
+
         auto req {PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
             .userAgent(userAgent)
             .postData(data)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());
@@ -249,23 +224,31 @@ void UNIXSocketRequest::patch(const URL& url,
     }
 }
 
-void UNIXSocketRequest::delete_(const URL& url,
-                                std::function<void(const std::string&)> onSuccess,
-                                std::function<void(const std::string&, const long)> onError,
-                                const std::string& fileName,
-                                const std::unordered_set<std::string>& httpHeaders,
-                                const SecureCommunication& secureCommunication,
-                                const std::string& userAgent,
-                                const CurlHandlerTypeEnum& handlerType,
-                                const std::atomic<bool>& shouldRun)
+void UNIXSocketRequest::delete_(RequestParameters requestParameters,
+                                PostRequestParameters postRequestParameters = {},
+                                ConfigurationParameters configurationParameters = {})
 {
+    // Request parameters
+    const auto& url {requestParameters.url};
+    std::string data;
+    const auto& secureCommunication {requestParameters.secureCommunication};
+    const auto& httpHeaders {requestParameters.httpHeaders};
+    // Post request parameters
+    const auto& onError {postRequestParameters.onError};
+    const auto& onSuccess {postRequestParameters.onSuccess};
+    const auto& outputFile {postRequestParameters.outputFile};
+    // Configuration parameters
+    const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
+
     try
     {
         auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
             .userAgent(userAgent)
-            .outputFile(fileName)
+            .outputFile(outputFile)
             .execute();
 
         onSuccess(req.response());

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -130,7 +130,7 @@ static void BM_Patch(benchmark::State& state)
     for (auto _ : state)
     {
         HTTPRequest::instance().patch(
-            RequestParameters {.url = HttpURL("http://localhost:44441/12345"), .data = R"({"foo": "bar"})"_json});
+            RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"foo": "bar"})"_json});
     }
 }
 BENCHMARK(BM_Patch);

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -85,7 +85,7 @@ static void BM_Get(benchmark::State& state)
 {
     for (auto _ : state)
     {
-        HTTPRequest::instance().get(HttpURL("http://localhost:44441/"), [&](const std::string& /*result*/) {});
+        HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/")});
     }
 }
 BENCHMARK(BM_Get);
@@ -100,7 +100,7 @@ static void BM_Post(benchmark::State& state)
     for (auto _ : state)
     {
         HTTPRequest::instance().post(
-            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})"_json, [&](const std::string& /*result*/) {});
+            RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"foo": "bar"})"_json});
     }
 }
 BENCHMARK(BM_Post);
@@ -115,7 +115,7 @@ static void BM_Update(benchmark::State& state)
     for (auto _ : state)
     {
         HTTPRequest::instance().put(
-            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})"_json, [&](const std::string& /*result*/) {});
+            RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"foo": "bar"})"_json});
     }
 }
 BENCHMARK(BM_Update);
@@ -130,7 +130,7 @@ static void BM_Patch(benchmark::State& state)
     for (auto _ : state)
     {
         HTTPRequest::instance().patch(
-            HttpURL("http://localhost:44441/"), R"({"foo": "bar"})"_json, [&](const std::string& /*result*/) {});
+            RequestParameters {.url = HttpURL("http://localhost:44441/12345"), .data = R"({"foo": "bar"})"_json});
     }
 }
 BENCHMARK(BM_Patch);
@@ -144,7 +144,7 @@ static void BM_Delete(benchmark::State& state)
 {
     for (auto _ : state)
     {
-        HTTPRequest::instance().delete_(HttpURL("http://localhost:44441/12345"), [&](const std::string& /*result*/) {});
+        HTTPRequest::instance().delete_(RequestParameters {.url = HttpURL("http://localhost:44441/12345")});
     }
 }
 
@@ -159,9 +159,8 @@ static void BM_Download(benchmark::State& state)
 {
     for (auto _ : state)
     {
-        HTTPRequest::instance().download(HttpURL("http://localhost:44441/"),
-                                         "out.txt",
-                                         [&](const std::string& /*result*/, const long /*responseCode*/) {});
+        HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                         PostRequestParameters {.outputFile = "out.txt"});
     }
 }
 BENCHMARK(BM_Download);
@@ -175,14 +174,9 @@ static void BM_DownloadUsingTheSingleHandler(benchmark::State& state)
 {
     for (auto _ : state)
     {
-        HTTPRequest::instance().download(
-            HttpURL("http://localhost:44441/"),
-            "out.txt",
-            [&](const std::string& /*result*/, const long /*responseCode*/) {},
-            {},
-            {},
-            {},
-            CurlHandlerTypeEnum::SINGLE);
+        HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                         PostRequestParameters {.outputFile = "out.txt"},
+                                         ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::SINGLE});
     }
 }
 BENCHMARK(BM_DownloadUsingTheSingleHandler);
@@ -196,14 +190,9 @@ static void BM_CustomDownloadUsingTheMultiHandler(benchmark::State& state)
 {
     for (auto _ : state)
     {
-        HTTPRequest::instance().download(
-            HttpURL("http://localhost:44441/"),
-            "out.txt",
-            [&](const std::string& /*result*/, const long /*responseCode*/) {},
-            {},
-            {},
-            {},
-            CurlHandlerTypeEnum::MULTI);
+        HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                         PostRequestParameters {.outputFile = "out.txt"},
+                                         ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI});
     }
 }
 BENCHMARK(BM_CustomDownloadUsingTheMultiHandler);

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -487,8 +487,6 @@ TEST_F(ComponentTestInterface, DeleteRandomIDFile)
  */
 TEST_F(ComponentTestInterface, DeleteRandomIDFileEmptyURL)
 {
-    auto random {std::to_string(std::rand())};
-
     HTTPRequest::instance().delete_(
         RequestParameters {.url = HttpURL("")},
         PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -23,12 +23,12 @@
  */
 TEST_F(ComponentTestInterface, GetHelloWorld)
 {
-    HTTPRequest::instance().get(HttpURL("http://localhost:44441/"),
-                                [&](const std::string& result)
-                                {
-                                    EXPECT_EQ(result, "Hello World!");
-                                    m_callbackComplete = true;
-                                });
+    HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                PostRequestParameters {.onSuccess = [&](const std::string& result)
+                                                       {
+                                                           EXPECT_EQ(result, "Hello World!");
+                                                           m_callbackComplete = true;
+                                                       }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -38,12 +38,12 @@ TEST_F(ComponentTestInterface, GetHelloWorld)
  */
 TEST_F(ComponentTestInterface, GetHelloWorldRedirection)
 {
-    HTTPRequest::instance().get(HttpURL("http://localhost:44441/redirect"),
-                                [&](const std::string& result)
-                                {
-                                    EXPECT_EQ(result, "Hello World!");
-                                    m_callbackComplete = true;
-                                });
+    HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/redirect")},
+                                PostRequestParameters {.onSuccess = [&](const std::string& result)
+                                                       {
+                                                           EXPECT_EQ(result, "Hello World!");
+                                                           m_callbackComplete = true;
+                                                       }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -53,13 +53,13 @@ TEST_F(ComponentTestInterface, GetHelloWorldRedirection)
  */
 TEST_F(ComponentTestInterface, PostHelloWorld)
 {
-    HTTPRequest::instance().post(HttpURL("http://localhost:44441/"),
-                                 R"({"hello":"world"})"_json,
-                                 [&](const std::string& result)
-                                 {
-                                     EXPECT_EQ(result, R"({"hello":"world"})");
-                                     m_callbackComplete = true;
-                                 });
+    HTTPRequest::instance().post(
+        RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess = [&](const std::string& result)
+                               {
+                                   EXPECT_EQ(result, R"({"hello":"world"})");
+                                   m_callbackComplete = true;
+                               }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -69,13 +69,13 @@ TEST_F(ComponentTestInterface, PostHelloWorld)
  */
 TEST_F(ComponentTestInterface, PutHelloWorld)
 {
-    HTTPRequest::instance().put(HttpURL("http://localhost:44441/"),
-                                R"({"hello":"world"})"_json,
-                                [&](const std::string& result)
-                                {
-                                    EXPECT_EQ(result, R"({"hello":"world"})");
-                                    m_callbackComplete = true;
-                                });
+    HTTPRequest::instance().put(
+        RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess = [&](const std::string& result)
+                               {
+                                   EXPECT_EQ(result, R"({"hello":"world"})");
+                                   m_callbackComplete = true;
+                               }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -87,12 +87,12 @@ TEST_F(ComponentTestInterface, DeleteRandomID)
 {
     auto random {std::to_string(std::rand())};
 
-    HTTPRequest::instance().delete_(HttpURL("http://localhost:44441/" + random),
-                                    [&](const std::string& result)
-                                    {
-                                        EXPECT_EQ(result, random);
-                                        m_callbackComplete = true;
-                                    });
+    HTTPRequest::instance().delete_(RequestParameters {.url = HttpURL("http://localhost:44441/" + random)},
+                                    PostRequestParameters {.onSuccess = [&](const std::string& result)
+                                                           {
+                                                               EXPECT_EQ(result, random);
+                                                               m_callbackComplete = true;
+                                                           }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -102,7 +102,8 @@ TEST_F(ComponentTestInterface, DeleteRandomID)
  */
 TEST_F(ComponentTestInterface, DownloadFile)
 {
-    HTTPRequest::instance().download(HttpURL("http://localhost:44441/"), "./test.txt", [](auto, auto) {});
+    HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                     PostRequestParameters {.outputFile = "./test.txt"});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -115,15 +116,17 @@ TEST_F(ComponentTestInterface, DownloadFile)
  */
 TEST_F(ComponentTestInterface, DownloadFileEmptyURL)
 {
-    HTTPRequest::instance().download(HttpURL(""),
-                                     "./test.txt",
-                                     [&](const std::string& result, const long responseCode)
-                                     {
-                                         EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
-                                         EXPECT_EQ(responseCode, -1);
+    HTTPRequest::instance().download(
+        RequestParameters {.url = HttpURL("")},
+        PostRequestParameters {.onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
+                                   EXPECT_EQ(responseCode, -1);
 
-                                         m_callbackComplete = true;
-                                     });
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./test.txt"});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -136,15 +139,16 @@ TEST_F(ComponentTestInterface, DownloadFileEmptyURL)
  */
 TEST_F(ComponentTestInterface, DownloadFileError)
 {
-    HTTPRequest::instance().download(HttpURL("http://localhost:44441/invalid_file"),
-                                     "./test.txt",
-                                     [&](const std::string& result, const long responseCode)
-                                     {
-                                         EXPECT_EQ(result, "HTTP response code said error");
-                                         EXPECT_EQ(responseCode, 404);
+    HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/invalid_file")},
+                                     PostRequestParameters {.onError =
+                                                                [&](const std::string& result, const long responseCode)
+                                                            {
+                                                                EXPECT_EQ(result, "HTTP response code said error");
+                                                                EXPECT_EQ(responseCode, 404);
 
-                                         m_callbackComplete = true;
-                                     });
+                                                                m_callbackComplete = true;
+                                                            },
+                                                            .outputFile = "./test.txt"});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -154,8 +158,9 @@ TEST_F(ComponentTestInterface, DownloadFileError)
  */
 TEST_F(ComponentTestInterface, DownloadFileUsingTheSingleHandler)
 {
-    HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/"), "./test.txt", [](auto, auto) {}, {}, {}, {}, CurlHandlerTypeEnum::SINGLE);
+    HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                     PostRequestParameters {.outputFile = "./test.txt"},
+                                     ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::SINGLE});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -169,19 +174,17 @@ TEST_F(ComponentTestInterface, DownloadFileUsingTheSingleHandler)
 TEST_F(ComponentTestInterface, DownloadFileEmptyURLUsingTheSingleHandler)
 {
     HTTPRequest::instance().download(
-        HttpURL(""),
-        "./test.txt",
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL("")},
+        PostRequestParameters {.onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        {},
-        {},
-        {},
-        CurlHandlerTypeEnum::SINGLE);
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./test.txt"},
+        ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::SINGLE});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -194,20 +197,17 @@ TEST_F(ComponentTestInterface, DownloadFileEmptyURLUsingTheSingleHandler)
  */
 TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheSingleHandler)
 {
-    HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/invalid_file"),
-        "./test.txt",
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "HTTP response code said error");
-            EXPECT_EQ(responseCode, 404);
+    HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/invalid_file")},
+                                     PostRequestParameters {.onError =
+                                                                [&](const std::string& result, const long responseCode)
+                                                            {
+                                                                EXPECT_EQ(result, "HTTP response code said error");
+                                                                EXPECT_EQ(responseCode, 404);
 
-            m_callbackComplete = true;
-        },
-        {},
-        {},
-        {},
-        CurlHandlerTypeEnum::SINGLE);
+                                                                m_callbackComplete = true;
+                                                            },
+                                                            .outputFile = "./test.txt"},
+                                     ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::SINGLE});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -220,14 +220,9 @@ TEST_F(ComponentTestInterface, DownloadFileUsingTheMultiHandler)
     std::atomic<bool> shouldRun {true};
 
     HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/"),
-        "./test.txt",
-        [](auto, auto) {},
-        {},
-        {},
-        {},
-        CurlHandlerTypeEnum::MULTI,
-        shouldRun);
+        RequestParameters {.url = HttpURL("http://localhost:44441/")},
+        PostRequestParameters {.outputFile = "./test.txt"},
+        ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = shouldRun});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -243,14 +238,9 @@ TEST_F(ComponentTestInterface, InterruptMultiHandler)
     std::atomic<bool> shouldRun {false};
 
     HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/"),
-        "./test.txt",
-        [](auto, auto) {},
-        {},
-        {},
-        {},
-        CurlHandlerTypeEnum::MULTI,
-        shouldRun);
+        RequestParameters {.url = HttpURL("http://localhost:44441/")},
+        PostRequestParameters {.outputFile = "./test.txt"},
+        ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = shouldRun});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -274,28 +264,18 @@ TEST_F(ComponentTestInterface, InterruptDownload)
         [&shouldRun, &sleepFirstHandler]()
         {
             HTTPRequest::instance().download(
-                HttpURL("http://localhost:44441/sleep/" + sleepFirstHandler),
-                "./test1.txt",
-                [](auto, auto) {},
-                {},
-                {},
-                {},
-                CurlHandlerTypeEnum::MULTI,
-                shouldRun);
+                RequestParameters {.url = HttpURL("http://localhost:44441/sleep/" + sleepFirstHandler)},
+                PostRequestParameters {.outputFile = "./test1.txt"},
+                ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = shouldRun});
         });
 
     std::thread thread2(
         [&shouldRun, &sleepSecondHandler]()
         {
             HTTPRequest::instance().download(
-                HttpURL("http://localhost:44441/sleep/" + sleepSecondHandler),
-                "./test2.txt",
-                [](auto, auto) {},
-                {},
-                {},
-                {},
-                CurlHandlerTypeEnum::MULTI,
-                shouldRun);
+                RequestParameters {.url = HttpURL("http://localhost:44441/sleep/" + sleepSecondHandler)},
+                PostRequestParameters {.outputFile = "./test2.txt"},
+                ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = shouldRun});
         });
 
     // Sleep interval to interrupt the second handler.
@@ -325,20 +305,17 @@ TEST_F(ComponentTestInterface, DownloadFileEmptyURLUsingTheMultiHandler)
     std::atomic<bool> shouldRun {true};
 
     HTTPRequest::instance().download(
-        HttpURL(""),
-        "./test.txt",
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "cURLMultiHandler::execute() failed: curl_multi_add_handle");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL("")},
+        PostRequestParameters {.onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "cURLMultiHandler::execute() failed: curl_multi_add_handle");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        {},
-        {},
-        {},
-        CurlHandlerTypeEnum::MULTI,
-        shouldRun);
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./test.txt"},
+        ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = shouldRun});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -354,20 +331,17 @@ TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheMultiHandler)
     std::atomic<bool> shouldRun {true};
 
     HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/invalid_file"),
-        "./test.txt",
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "cURLMultiHandler::execute() failed: curl_multi_add_handle");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL("http://localhost:44441/invalid_file")},
+        PostRequestParameters {.onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "cURLMultiHandler::execute() failed: curl_multi_add_handle");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        {},
-        {},
-        {},
-        CurlHandlerTypeEnum::MULTI,
-        shouldRun);
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./test.txt"},
+        ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = shouldRun});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -377,11 +351,8 @@ TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheMultiHandler)
  */
 TEST_F(ComponentTestInterface, GetHelloWorldFile)
 {
-    HTTPRequest::instance().get(
-        HttpURL("http://localhost:44441/"),
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [](auto, auto) {},
-        "./testGetHelloWorld.txt");
+    HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/")},
+                                PostRequestParameters {.outputFile = "./testGetHelloWorld.txt"});
 
     std::ifstream file("./testGetHelloWorld.txt");
     std::string line;
@@ -395,16 +366,17 @@ TEST_F(ComponentTestInterface, GetHelloWorldFile)
 TEST_F(ComponentTestInterface, GetHelloWorldFileEmptyURL)
 {
     HTTPRequest::instance().get(
-        HttpURL(""),
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL("")},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        "./testGetHelloWorld.txt");
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./testGetHelloWorld.txt"});
 
     std::ifstream file("./testGetHelloWorld.txt");
     std::string line;
@@ -418,11 +390,9 @@ TEST_F(ComponentTestInterface, GetHelloWorldFileEmptyURL)
 TEST_F(ComponentTestInterface, PostHelloWorldFile)
 {
     HTTPRequest::instance().post(
-        HttpURL("http://localhost:44441/"),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [](auto, auto) {},
-        "./testPostHelloWorld.txt");
+        RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .outputFile = "./testPostHelloWorld.txt"});
 
     std::ifstream file("./testPostHelloWorld.txt");
     std::string line;
@@ -436,17 +406,17 @@ TEST_F(ComponentTestInterface, PostHelloWorldFile)
 TEST_F(ComponentTestInterface, PostHelloWorldFileEmptyURL)
 {
     HTTPRequest::instance().post(
-        HttpURL(""),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL(""), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        "./testPostHelloWorld.txt");
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./testPostHelloWorld.txt"});
 
     std::ifstream file("./testPostHelloWorld.txt");
     std::string line;
@@ -460,11 +430,9 @@ TEST_F(ComponentTestInterface, PostHelloWorldFileEmptyURL)
 TEST_F(ComponentTestInterface, PutHelloWorldFile)
 {
     HTTPRequest::instance().put(
-        HttpURL("http://localhost:44441/"),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [](auto, auto) {},
-        "./testPutHelloWorld.txt");
+        RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .outputFile = "./testPutHelloWorld.txt"});
 
     std::ifstream file("./testPutHelloWorld.txt");
     std::string line;
@@ -478,17 +446,17 @@ TEST_F(ComponentTestInterface, PutHelloWorldFile)
 TEST_F(ComponentTestInterface, PutHelloWorldFileEmptyURL)
 {
     HTTPRequest::instance().put(
-        HttpURL(""),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL(""), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        "./testPutHelloWorld.txt");
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./testPutHelloWorld.txt"});
 
     std::ifstream file("./testPutHelloWorld.txt");
     std::string line;
@@ -504,10 +472,9 @@ TEST_F(ComponentTestInterface, DeleteRandomIDFile)
     auto random {std::to_string(std::rand())};
 
     HTTPRequest::instance().delete_(
-        HttpURL("http://localhost:44441/" + random),
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [](auto, auto) {},
-        "./testDeleteRandomID.txt");
+        RequestParameters {.url = HttpURL("http://localhost:44441/" + random)},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .outputFile = "./testDeleteRandomID.txt"});
 
     std::ifstream file("./testDeleteRandomID.txt");
     std::string line;
@@ -523,16 +490,17 @@ TEST_F(ComponentTestInterface, DeleteRandomIDFileEmptyURL)
     auto random {std::to_string(std::rand())};
 
     HTTPRequest::instance().delete_(
-        HttpURL(""),
-        [&](const std::string& result) { std::cout << result << std::endl; },
-        [&](const std::string& result, const long responseCode)
-        {
-            EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
-            EXPECT_EQ(responseCode, -1);
+        RequestParameters {.url = HttpURL("")},
+        PostRequestParameters {.onSuccess = [&](const std::string& result) { std::cout << result << std::endl; },
+                               .onError =
+                                   [&](const std::string& result, const long responseCode)
+                               {
+                                   EXPECT_EQ(result, "URL using bad/illegal format or missing URL");
+                                   EXPECT_EQ(responseCode, -1);
 
-            m_callbackComplete = true;
-        },
-        "./testDeleteRandomID.txt");
+                                   m_callbackComplete = true;
+                               },
+                               .outputFile = "./testDeleteRandomID.txt"});
 
     std::ifstream file("./testDeleteRandomID.txt");
     std::string line;
@@ -790,16 +758,14 @@ TEST_F(ComponentTestInterface, GetWithCustomHeader)
     const std::string headerKey {"Custom-Key"};
     const std::string headerValue {"Custom-Value"};
 
-    HTTPRequest::instance().get(
-        HttpURL("http://localhost:44441/check-headers"),
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), headerValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {headerKey + ": " + headerValue});
+    HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/check-headers"),
+                                                   .httpHeaders = {headerKey + ":" + headerValue}},
+                                PostRequestParameters {.onSuccess = [&](const std::string& result)
+                                                       {
+                                                           ASSERT_EQ(nlohmann::json::parse(result).at(headerKey),
+                                                                     headerValue);
+                                                           m_callbackComplete = true;
+                                                       }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -810,22 +776,23 @@ TEST_F(ComponentTestInterface, GetWithCustomHeader)
  */
 TEST_F(ComponentTestInterface, GetWithDefaultHeaders)
 {
-    HTTPRequest::instance().get(
-        HttpURL("http://localhost:44441/check-headers"),
-        [&](const std::string& result)
-        {
-            const std::map<std::string, std::string> defaultHeaders = {
-                {"Content-Type", "application/json"}, {"Accept", "application/json"}, {"Accept-Charset", "utf-8"}};
-            const auto response = nlohmann::json::parse(result);
+    HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/check-headers")},
+                                PostRequestParameters {.onSuccess = [&](const std::string& result)
+                                                       {
+                                                           const std::map<std::string, std::string> defaultHeaders = {
+                                                               {"Content-Type", "application/json"},
+                                                               {"Accept", "application/json"},
+                                                               {"Accept-Charset", "utf-8"}};
+                                                           const auto response = nlohmann::json::parse(result);
 
-            ASSERT_FALSE(response.empty());
-            for (const auto& [headerKey, headerValue] : defaultHeaders)
-            {
-                ASSERT_EQ(response.at(headerKey), headerValue);
-            }
+                                                           ASSERT_FALSE(response.empty());
+                                                           for (const auto& [headerKey, headerValue] : defaultHeaders)
+                                                           {
+                                                               ASSERT_EQ(response.at(headerKey), headerValue);
+                                                           }
 
-            m_callbackComplete = true;
-        });
+                                                           m_callbackComplete = true;
+                                                       }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -843,19 +810,16 @@ TEST_F(ComponentTestInterface, PostWithCustomHeaders)
     const std::string headerValueB {"Custom-Value-B"};
 
     HTTPRequest::instance().post(
-        HttpURL("http://localhost:44441/check-headers"),
-        std::string(),
-        [&](const std::string& result)
-        {
-            const auto response = nlohmann::json::parse(result);
+        RequestParameters {.url = HttpURL("http://localhost:44441/check-headers"),
+                           .httpHeaders = {headerKeyA + ":" + headerValueA, headerKeyB + ":" + headerValueB}},
+        PostRequestParameters {.onSuccess = [&](const std::string& result)
+                               {
+                                   const auto response = nlohmann::json::parse(result);
 
-            ASSERT_EQ(response.at(headerKeyA), headerValueA);
-            ASSERT_EQ(response.at(headerKeyB), headerValueB);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {headerKeyA + ":" + headerValueA, headerKeyB + ":" + headerValueB});
+                                   ASSERT_EQ(response.at(headerKeyA), headerValueA);
+                                   ASSERT_EQ(response.at(headerKeyB), headerValueB);
+                                   m_callbackComplete = true;
+                               }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -871,16 +835,13 @@ TEST_F(ComponentTestInterface, PutWithCustomHeaders)
     const std::string headerValue {"Custom-Value"};
 
     HTTPRequest::instance().put(
-        HttpURL("http://localhost:44441/check-headers"),
-        std::string(),
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), headerValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {headerKey + ":" + headerValue, headerKey + ":" + headerValue});
+        RequestParameters {.url = HttpURL("http://localhost:44441/check-headers"),
+                           .httpHeaders = {headerKey + ":" + headerValue, headerKey + ":" + headerValue}},
+        PostRequestParameters {.onSuccess = [&](const std::string& result)
+                               {
+                                   ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), headerValue);
+                                   m_callbackComplete = true;
+                               }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -900,13 +861,12 @@ TEST_F(ComponentTestInterface, PatchSimpleFunctionality)
     )"_json;
     expectedResponse["payload"] = postData;
 
-    HTTPRequest::instance().patch(HttpURL("http://localhost:44441/"),
-                                  postData,
-                                  [&](const std::string& response)
-                                  {
-                                      EXPECT_EQ(nlohmann::json::parse(response), expectedResponse);
-                                      m_callbackComplete = true;
-                                  });
+    HTTPRequest::instance().patch(RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = postData},
+                                  PostRequestParameters {.onSuccess = [&](const std::string& result)
+                                                         {
+                                                             EXPECT_EQ(nlohmann::json::parse(result), expectedResponse);
+                                                             m_callbackComplete = true;
+                                                         }});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -919,7 +879,9 @@ TEST_F(ComponentTestInterface, DownloadWithCustomUserAgent)
     const std::string userAgent {"Custom-User-Agent"};
 
     HTTPRequest::instance().download(
-        HttpURL("http://localhost:44441/"), "./test.txt", [](auto, auto) {}, DEFAULT_HEADERS, {}, userAgent);
+        RequestParameters {.url = HttpURL("http://localhost:44441/"), .httpHeaders = DEFAULT_HEADERS},
+        PostRequestParameters {.outputFile = "./test.txt"},
+        ConfigurationParameters {.userAgent = userAgent});
 
     std::ifstream file("./test.txt");
     std::string line;
@@ -936,18 +898,14 @@ TEST_F(ComponentTestInterface, PostWithCustomUserAgent)
     const std::string userAgentValue {"Custom-User-Agent"};
 
     HTTPRequest::instance().post(
-        HttpURL("http://localhost:44441/check-headers"),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {},
-        {},
-        userAgentValue);
+        RequestParameters {.url = HttpURL("http://localhost:44441/check-headers"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess =
+                                   [&](const std::string& result)
+                               {
+                                   ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
+                                   m_callbackComplete = true;
+                               }},
+        ConfigurationParameters {.userAgent = userAgentValue});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -961,18 +919,15 @@ TEST_F(ComponentTestInterface, GetWithCustomUserAgent)
     const std::string headerKey {"User-Agent"};
     const std::string userAgentValue {"Custom-User-Agent"};
 
-    HTTPRequest::instance().get(
-        HttpURL("http://localhost:44441/check-headers"),
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {},
-        {},
-        userAgentValue);
+    HTTPRequest::instance().get(RequestParameters {.url = HttpURL("http://localhost:44441/check-headers")},
+                                PostRequestParameters {.onSuccess =
+                                                           [&](const std::string& result)
+                                                       {
+                                                           ASSERT_EQ(nlohmann::json::parse(result).at(headerKey),
+                                                                     userAgentValue);
+                                                           m_callbackComplete = true;
+                                                       }},
+                                ConfigurationParameters {.userAgent = userAgentValue});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -987,18 +942,14 @@ TEST_F(ComponentTestInterface, PutWithCustomUserAgent)
     const std::string userAgentValue {"Custom-User-Agent"};
 
     HTTPRequest::instance().put(
-        HttpURL("http://localhost:44441/check-headers"),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {},
-        {},
-        userAgentValue);
+        RequestParameters {.url = HttpURL("http://localhost:44441/check-headers"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess =
+                                   [&](const std::string& result)
+                               {
+                                   ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
+                                   m_callbackComplete = true;
+                               }},
+        ConfigurationParameters {.userAgent = userAgentValue});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -1013,18 +964,14 @@ TEST_F(ComponentTestInterface, PatchWithCustomUserAgent)
     const std::string userAgentValue {"Custom-User-Agent"};
 
     HTTPRequest::instance().patch(
-        HttpURL("http://localhost:44441/check-headers"),
-        R"({"hello":"world"})"_json,
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {},
-        {},
-        userAgentValue);
+        RequestParameters {.url = HttpURL("http://localhost:44441/check-headers"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess =
+                                   [&](const std::string& result)
+                               {
+                                   ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
+                                   m_callbackComplete = true;
+                               }},
+        ConfigurationParameters {.userAgent = userAgentValue});
 
     EXPECT_TRUE(m_callbackComplete);
 }
@@ -1038,18 +985,15 @@ TEST_F(ComponentTestInterface, DeleteWithCustomUserAgent)
     const std::string headerKey {"User-Agent"};
     const std::string userAgentValue {"Custom-User-Agent"};
 
-    HTTPRequest::instance().delete_(
-        HttpURL("http://localhost:44441/check-headers"),
-        [&](const std::string& result)
-        {
-            ASSERT_EQ(nlohmann::json::parse(result).at(headerKey), userAgentValue);
-            m_callbackComplete = true;
-        },
-        [](auto, auto) {},
-        "",
-        {},
-        {},
-        userAgentValue);
+    HTTPRequest::instance().delete_(RequestParameters {.url = HttpURL("http://localhost:44441/check-headers")},
+                                    PostRequestParameters {.onSuccess =
+                                                               [&](const std::string& result)
+                                                           {
+                                                               ASSERT_EQ(nlohmann::json::parse(result).at(headerKey),
+                                                                         userAgentValue);
+                                                               m_callbackComplete = true;
+                                                           }},
+                                    ConfigurationParameters {.userAgent = userAgentValue});
 
     EXPECT_TRUE(m_callbackComplete);
 }

--- a/test_tool/actions.hpp
+++ b/test_tool/actions.hpp
@@ -64,15 +64,15 @@ public:
     void execute() override
     {
         HTTPRequest::instance().download(
-            HttpURL(m_url),
-            m_outputFile,
-            [](const std::string& msg, const long responseCode)
-            {
-                std::cerr << msg << ": " << responseCode << std::endl;
-                throw std::runtime_error(msg);
-            },
-            m_headers,
-            m_secureCommunication);
+            RequestParameters {
+                .url = HttpURL(m_url), .secureCommunication = m_secureCommunication, .httpHeaders = m_headers},
+            PostRequestParameters {.onError =
+                                       [](const std::string& msg, const long responseCode)
+                                   {
+                                       std::cerr << msg << ": " << responseCode << std::endl;
+                                       throw std::runtime_error(msg);
+                                   },
+                                   .outputFile = m_outputFile});
     }
 };
 
@@ -108,16 +108,15 @@ public:
     void execute() override
     {
         HTTPRequest::instance().get(
-            HttpURL(m_url),
-            [](const std::string& msg) { std::cout << msg << std::endl; },
-            [](const std::string& msg, const long responseCode)
-            {
-                std::cerr << msg << ": " << responseCode << std::endl;
-                throw std::runtime_error(msg);
-            },
-            "",
-            m_headers,
-            m_secureCommunication);
+            RequestParameters {
+                .url = HttpURL(m_url), .secureCommunication = m_secureCommunication, .httpHeaders = m_headers},
+            PostRequestParameters {.onSuccess = [](const std::string& msg) { std::cout << msg << std::endl; },
+                                   .onError =
+                                       [](const std::string& msg, const long responseCode)
+                                   {
+                                       std::cerr << msg << ": " << responseCode << std::endl;
+                                       throw std::runtime_error(msg);
+                                   }});
     }
 };
 
@@ -156,18 +155,18 @@ public:
      */
     void execute() override
     {
-        HTTPRequest::instance().post(
-            HttpURL(m_url),
-            m_data,
-            [](const std::string& msg) { std::cout << msg << std::endl; },
-            [](const std::string& msg, const long responseCode)
-            {
-                std::cerr << msg << ": " << responseCode << std::endl;
-                throw std::runtime_error(msg);
-            },
-            "",
-            m_headers,
-            m_secureCommunication);
+        HTTPRequest::instance().post(RequestParameters {.url = HttpURL(m_url),
+                                                        .secureCommunication = m_secureCommunication,
+                                                        .httpHeaders = m_headers},
+                                     PostRequestParameters {
+                                         .onSuccess = [](const std::string& msg) { std::cout << msg << std::endl; },
+                                         .onError =
+                                             [](const std::string& msg, const long responseCode)
+                                         {
+                                             std::cerr << msg << ": " << responseCode << std::endl;
+                                             throw std::runtime_error(msg);
+                                         },
+                                     });
     }
 };
 
@@ -207,17 +206,17 @@ public:
     void execute() override
     {
         HTTPRequest::instance().put(
-            HttpURL(m_url),
-            m_data,
-            [](const std::string& msg) { std::cout << msg << std::endl; },
-            [](const std::string& msg, const long responseCode)
-            {
-                std::cerr << msg << ": " << responseCode << std::endl;
-                throw std::runtime_error(msg);
-            },
-            "",
-            m_headers,
-            m_secureCommunication);
+            RequestParameters {.url = HttpURL(m_url),
+                               .data = m_data,
+                               .secureCommunication = m_secureCommunication,
+                               .httpHeaders = m_headers},
+            PostRequestParameters {.onSuccess = [](const std::string& msg) { std::cout << msg << std::endl; },
+                                   .onError =
+                                       [](const std::string& msg, const long responseCode)
+                                   {
+                                       std::cerr << msg << ": " << responseCode << std::endl;
+                                       throw std::runtime_error(msg);
+                                   }});
     }
 };
 
@@ -260,17 +259,17 @@ public:
     void execute() override
     {
         HTTPRequest::instance().patch(
-            HttpURL(m_url),
-            m_data,
-            [](const std::string& msg) { std::cout << msg << std::endl; },
-            [](const std::string& msg, const long responseCode)
-            {
-                std::cerr << msg << ": " << responseCode << std::endl;
-                throw std::runtime_error(msg);
-            },
-            "",
-            m_headers,
-            m_secureCommunication);
+            RequestParameters {.url = HttpURL(m_url),
+                               .data = m_data,
+                               .secureCommunication = m_secureCommunication,
+                               .httpHeaders = m_headers},
+            PostRequestParameters {.onSuccess = [](const std::string& msg) { std::cout << msg << std::endl; },
+                                   .onError =
+                                       [](const std::string& msg, const long responseCode)
+                                   {
+                                       std::cerr << msg << ": " << responseCode << std::endl;
+                                       throw std::runtime_error(msg);
+                                   }});
     }
 };
 
@@ -306,16 +305,15 @@ public:
     void execute() override
     {
         HTTPRequest::instance().delete_(
-            HttpURL(m_url),
-            [](const std::string& msg) { std::cout << msg << std::endl; },
-            [](const std::string& msg, const long responseCode)
-            {
-                std::cerr << msg << ": " << responseCode << std::endl;
-                throw std::runtime_error(msg);
-            },
-            "",
-            m_headers,
-            m_secureCommunication);
+            RequestParameters {
+                .url = HttpURL(m_url), .secureCommunication = m_secureCommunication, .httpHeaders = m_headers},
+            PostRequestParameters {.onSuccess = [](const std::string& msg) { std::cout << msg << std::endl; },
+                                   .onError =
+                                       [](const std::string& msg, const long responseCode)
+                                   {
+                                       std::cerr << msg << ": " << responseCode << std::endl;
+                                       throw std::runtime_error(msg);
+                                   }});
     }
 };
 


### PR DESCRIPTION
| Related issue |
|--------|
| Closes #60 |

## Description

This PR updates all the interfaces to make them more clear to be used and read. Also, future additions of parameters should be easier and will require less time to be implemented.

Some references were considered for the refactoring ([How to Design Function Parameters That Make Interfaces Easier to Use - Fluent C++](https://www.fluentcpp.com/2018/11/23/function-parameters-making-interfaces-easy-to-use/)).
The proposal divides the parameters in three categories: general parameters that will be used in the query itself (what to do), optional configuration parameters to tune the behavior of the query (how to do it), and post-request parameters to define actions to take with the query results (what to after).

Each category is a structure, and only the first one is mandatory. This simplifies the simpler calls, and avoids writing unnecessary default values.
For the most complex method calls, each field name is used, making the reading easier.

## Testing

<details><summary>UT Pass</summary>
<p>

```bash
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test# ctest
Test project /workspaces/wazuh-http-request/build/test
    Start 1: urlrequest_benchmark_test
1/3 Test #1: urlrequest_benchmark_test ........   Passed   16.45 sec
    Start 2: urlrequest_component_test
2/3 Test #2: urlrequest_component_test ........   Passed    0.09 sec
    Start 3: urlrequest_unit_test
3/3 Test #3: urlrequest_unit_test .............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =  16.56 sec
```

</p>
</details> 

<details><summary>Test tool</summary>
<p>

```
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# ./urlrequest_testtool -u https://httpbin.org/get -t download -o out
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# cat out 
{
  "args": {}, 
  "headers": {
    "Accept": "application/json", 
    "Accept-Charset": "utf-8", 
    "Authorization": "Basic Og==", 
    "Content-Type": "application/json", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-66aaf590-7c9af3040a6c790f576c7ec7"
  }, 
  "origin": "REDACTED", 
  "url": "https://httpbin.org/get"
}
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# 
```

```
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# ./urlrequest_testtool -u https://httpbin.org/get -t get
{
  "args": {}, 
  "headers": {
    "Accept": "application/json", 
    "Accept-Charset": "utf-8", 
    "Authorization": "Basic Og==", 
    "Content-Type": "application/json", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-66aaf5e1-0c8ecb815e30e8ce69004139"
  }, 
  "origin": "REDACTED", 
  "url": "https://httpbin.org/get"
}
```

```
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# ./urlrequest_testtool -u https://httpbin.org/post -t post -p out 
{
  "args": {}, 
  "data": "", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept": "application/json", 
    "Accept-Charset": "utf-8", 
    "Authorization": "Basic Og==", 
    "Content-Length": "0", 
    "Content-Type": "application/json", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-66aaf614-1c4b61756a9bf32030050cb7"
  }, 
  "json": null, 
  "origin": "REDACTED", 
  "url": "https://httpbin.org/post"
}
```

```
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# ./urlrequest_testtool -u https://httpbin.org/put -t put -p out 
{
  "args": {}, 
  "data": "{\"args\":{},\"headers\":{\"Accept\":\"application/json\",\"Accept-Charset\":\"utf-8\",\"Authorization\":\"Basic Og==\",\"Content-Type\":\"application/json\",\"Host\":\"httpbin.org\",\"X-Amzn-Trace-Id\":\"Root=1-66aaf590-7c9af3040a6c790f576c7ec7\"},\"origin\":\"REDACTED\",\"url\":\"https://httpbin.org/get\"}", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept": "application/json", 
    "Accept-Charset": "utf-8", 
    "Authorization": "Basic Og==", 
    "Content-Length": "276", 
    "Content-Type": "application/json", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-66aaf641-43ffce5164024ce97229cef4"
  }, 
  "json": {
    "args": {}, 
    "headers": {
      "Accept": "application/json", 
      "Accept-Charset": "utf-8", 
      "Authorization": "Basic Og==", 
      "Content-Type": "application/json", 
      "Host": "httpbin.org", 
      "X-Amzn-Trace-Id": "Root=1-66aaf590-7c9af3040a6c790f576c7ec7"
    }, 
    "origin": "REDACTED", 
    "url": "https://httpbin.org/get"
  }, 
  "origin": "REDACTED", 
  "url": "https://httpbin.org/put"
}
```

```
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# ./urlrequest_testtool -u https://httpbin.org/delete -t delete
{
  "args": {}, 
  "data": "", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept": "application/json", 
    "Accept-Charset": "utf-8", 
    "Authorization": "Basic Og==", 
    "Content-Type": "application/json", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-66aaf671-0599723c13d6040d2f651a42"
  }, 
  "json": null, 
  "origin": "REDACTED", 
  "url": "https://httpbin.org/delete"
}
```

```
root@6f68a3e7a4f3:/workspaces/wazuh-http-request/build/test_tool# ./urlrequest_testtool -u https://httpbin.org/get -t get -H "Authorization: Bearer token"
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Authorization": "Bearer token", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-66aaf68f-187e16fd224251d07af53400"
  }, 
  "origin": "REDACTED", 
  "url": "https://httpbin.org/get"
}
```

</p>
</details> 

## Examples

Here we have the most representative examples of the implementation, comparing the current approach against the new one.

<details><summary>Only required parameters are written</summary>
<p>

Here we don't need to write all the empty curly braces and only the three meaningful fields are written

![2024-07-31_23-27](https://github.com/user-attachments/assets/8aa5ce6c-b6c8-4c05-893a-1824a416be7d)


</p>
</details> 

<details><summary>Each parameter has its name</summary>
<p>

The lambda parameters can be confused, but now that each one has its name, they can't.
Also, the configuration structure can be committed because it doesn't contain relevant parameters for this call.

![2024-07-31_23-30](https://github.com/user-attachments/assets/2a640d8f-3339-4065-916a-9d6da0a58b50)


</p>
</details> 





