### PR TITLE
Fix MULTI handler request

### DIFF
--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -317,10 +317,12 @@ void HTTPRequest::delete_(RequestParameters requestParameters,
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
+    const auto& handlerType {configurationParameters.handlerType};
+    const auto& shouldRun {configurationParameters.shouldRun};
 
     try
     {
-        auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
+        auto req {DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .appendHeaders(httpHeaders)
             .timeout(timeout)

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -321,7 +321,7 @@ void UNIXSocketRequest::delete_(RequestParameters requestParameters,
 
     try
     {
-        auto req {DeleteRequest::builder(FactoryRequestWrapper<cURLWrapper>::create())};
+        auto req {DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
         req.url(url.url(), secureCommunication)
             .unixSocketPath(url.unixSocketPath())
             .timeout(timeout)

--- a/src/curlMultiHandler.hpp
+++ b/src/curlMultiHandler.hpp
@@ -78,7 +78,7 @@ public:
 
             do
             {
-                // Performs transfers on the added single-handler
+                // Performs transfers on the added multi-handler
                 multiCode = curl_multi_perform(m_curlMultiHandler.get(), &stillRunning);
 
                 if (multiCode != CURLM_OK)

--- a/test/benchmark/main.cpp
+++ b/test/benchmark/main.cpp
@@ -188,7 +188,6 @@ BENCHMARK(BM_DownloadUsingTheSingleHandler);
  */
 static void BM_CustomDownloadUsingTheMultiHandler(benchmark::State& state)
 {
-    state.SkipWithError("This test will wait until #63 is fixed");
     for (auto _ : state)
     {
         HTTPRequest::instance().download(RequestParameters {.url = HttpURL("http://localhost:44441/")},

--- a/test/component/CMakeLists.txt
+++ b/test/component/CMakeLists.txt
@@ -4,6 +4,8 @@ project(urlrequest_component_test)
 file(GLOB URL_REQUEST_COMPONENT_TEST_SRC *.cpp)
 
 add_executable(urlrequest_component_test ${URL_REQUEST_COMPONENT_TEST_SRC})
+target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address")
+target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address")
 target_link_libraries(urlrequest_component_test urlrequest
     gtest
     gmock
@@ -11,4 +13,4 @@ target_link_libraries(urlrequest_component_test urlrequest
     gmock_main)
 
 add_test(NAME urlrequest_component_test
-         COMMAND urlrequest_component_test)
+    COMMAND urlrequest_component_test)

--- a/test/component/CMakeLists.txt
+++ b/test/component/CMakeLists.txt
@@ -4,8 +4,10 @@ project(urlrequest_component_test)
 file(GLOB URL_REQUEST_COMPONENT_TEST_SRC *.cpp)
 
 add_executable(urlrequest_component_test ${URL_REQUEST_COMPONENT_TEST_SRC})
-target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address")
-target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address")
+
+target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
+target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
+
 target_link_libraries(urlrequest_component_test urlrequest
     gtest
     gmock

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -154,6 +154,10 @@ protected:
      * @brief This variable is used as a flag to indicate if all the callbacks have been called.
      */
     bool m_callbackComplete = false;
+
+    /**
+     * @brief This variable is used as a flag to indicate if the test should run.
+     */
     std::atomic<bool> m_shouldRun {true};
 
     virtual ~ComponentTest() = default;

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -12,6 +12,8 @@
 #ifndef _COMPONENT_TEST_H
 #define _COMPONENT_TEST_H
 
+#include "IURLRequest.hpp"
+#include "curlHandlerCache.hpp"
 #include "json.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -152,6 +154,8 @@ protected:
      * @brief This variable is used as a flag to indicate if all the callbacks have been called.
      */
     bool m_callbackComplete = false;
+    std::atomic<bool> m_shouldRun {true};
+
     virtual ~ComponentTest() = default;
     /**
      * @brief This method is called before each test to initialize the test environment.
@@ -159,6 +163,7 @@ protected:
     void SetUp() override
     {
         m_callbackComplete = false;
+        m_shouldRun.store(true);
     }
 
     /**
@@ -167,8 +172,10 @@ protected:
      */
     void TearDown() override
     {
+        m_shouldRun.store(false);
         std::filesystem::remove(TEST_FILE_1);
         std::filesystem::remove(TEST_FILE_2);
+        cURLHandlerCache::instance().clear();
     }
 
     /**

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -4,8 +4,10 @@ project(urlrequest_unit_test)
 file(GLOB URL_REQUEST_UNIT_TEST_SRC *.cpp)
 
 add_executable(urlrequest_unit_test ${URL_REQUEST_UNIT_TEST_SRC})
-target_compile_options(urlrequest_unit_test PUBLIC "-fsanitize=address")
-target_link_options(urlrequest_unit_test PUBLIC "-fsanitize=address")
+
+target_compile_options(urlrequest_unit_test PUBLIC "-fsanitize=address,leak,undefined")
+target_link_options(urlrequest_unit_test PUBLIC "-fsanitize=address,leak,undefined")
+
 target_link_libraries(urlrequest_unit_test urlrequest
     gtest
     gmock

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -4,6 +4,8 @@ project(urlrequest_unit_test)
 file(GLOB URL_REQUEST_UNIT_TEST_SRC *.cpp)
 
 add_executable(urlrequest_unit_test ${URL_REQUEST_UNIT_TEST_SRC})
+target_compile_options(urlrequest_unit_test PUBLIC "-fsanitize=address")
+target_link_options(urlrequest_unit_test PUBLIC "-fsanitize=address")
 target_link_libraries(urlrequest_unit_test urlrequest
     gtest
     gmock
@@ -11,4 +13,4 @@ target_link_libraries(urlrequest_unit_test urlrequest
     gmock_main)
 
 add_test(NAME urlrequest_unit_test
-         COMMAND urlrequest_unit_test)
+    COMMAND urlrequest_unit_test)


### PR DESCRIPTION
| Related issue |
|--------|
| Closes #63 |


## Description

This PR adds the missing mechanism of `curl_multi_remove_handle()` after every query execution (even with error) to avoid the exception of trying to add the same handler more than once.

Also:
- The component/unit tests now use address sanitizer
- The `download_` request can be used as MULTI
- Some extra checks were added to the component tests 