### PR TITLE
Added sopport for insecure mode (skip verification certs)

### DIFF
--- a/include/secureCommunication.hpp
+++ b/include/secureCommunication.hpp
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <string>
+#include <variant>
 
 namespace urlrequest
 {
@@ -22,7 +23,8 @@ enum class AuthenticationParameter
     SSL_CERTIFICATE,
     SSL_KEY,
     CA_ROOT_CERTIFICATE,
-    BASIC_AUTH_CREDS
+    BASIC_AUTH_CREDS,
+    SKIP_PEER_VERIFICATION
 };
 /**
  * @brief This class provides a simple interface to construct an object using a Builder pattern.
@@ -63,7 +65,7 @@ public:
 class SecureCommunication final : public urlrequest::Builder<SecureCommunication>
 {
 private:
-    std::map<urlrequest::AuthenticationParameter, std::string> m_parameters;
+    std::map<urlrequest::AuthenticationParameter, std::variant<std::string, bool>> m_parameters;
 
 public:
     /**
@@ -115,18 +117,32 @@ public:
     }
 
     /**
+     * @brief Set the Skip Peer Verification.
+     *
+     * @param skipPeerVerification Skip peer verification.
+     */
+    SecureCommunication& skipPeerVerification(const bool skipPeerVerification)
+    {
+        m_parameters[urlrequest::AuthenticationParameter::SKIP_PEER_VERIFICATION] = skipPeerVerification;
+
+        return (*this);
+    }
+
+    /**
      * @brief Get parameters.
      *
+     * @tparam T Type of the parameter, std::string or bool.
      * @param parameter AuthenticationParameter Parameter to get.
      *
-     * @return std::string Parameter value.
+     * @return T Parameter value.
      */
-    std::string getParameter(const urlrequest::AuthenticationParameter parameter) const
+    template<typename T = std::string>
+    T getParameter(const urlrequest::AuthenticationParameter parameter) const
     {
         auto it = m_parameters.find(parameter);
         if (it != m_parameters.end())
         {
-            return it->second;
+            return std::get<T>(it->second);
         }
         return {};
     }

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -196,10 +196,10 @@ public:
                 }
             }
 
-            if (m_certificate.empty())
-            {
-                m_requestImplementator->setOption(OPT_VERIFYPEER, 0L);
-            }
+            const auto skipVerify =
+                secureCommunication.getParameter<bool>(urlrequest::AuthenticationParameter::SKIP_PEER_VERIFICATION);
+
+            m_requestImplementator->setOption(OPT_VERIFYPEER, skipVerify ? 0L : 1L);
         }
 
         const auto authCreds = secureCommunication.getParameter(urlrequest::AuthenticationParameter::BASIC_AUTH_CREDS);

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -268,7 +268,6 @@ public:
     {
         m_certificate = cert;
         m_requestImplementator->setOption(OPT_CAINFO, m_certificate);
-        m_requestImplementator->setOption(OPT_VERIFYPEER, 1L);
 
         return static_cast<T&>(*this);
     }

--- a/test_tool/cmdArgsParser.hpp
+++ b/test_tool/cmdArgsParser.hpp
@@ -38,6 +38,7 @@ public:
         , m_key {paramValueOf(argc, argv, "--key", {false, ""})}
         , m_username {paramValueOf(argc, argv, "--username", {false, ""})}
         , m_password {paramValueOf(argc, argv, "--password", {false, ""})}
+        , m_skipVerifyPeer {paramValueOf(argc, argv, "--skip-verify-peer", {false, "false"}) == "true"}
         , m_timeout {std::stol(paramValueOf(argc, argv, "--timeout", {false, "0"}))}
     {
         auto postArgumentsFile {paramValueOf(argc, argv, "-p", {false, ""})};
@@ -136,6 +137,16 @@ public:
     }
 
     /**
+     * @brief Returns if the peer verification should be skipped.
+     *
+     * @return true if the peer verification should be skipped, false otherwise.
+     */
+    const bool skipVerifyPeer() const
+    {
+        return m_skipVerifyPeer;
+    }
+
+    /**
      * @brief Returns the timeout.
      */
     const long& timeout() const
@@ -163,6 +174,7 @@ public:
             << "\t--key KEY\t\tSpecifies the key file to use in the request.\n"
             << "\t--username USERNAME\tSpecifies the username to use in the request.\n"
             << "\t--password PASSWORD\tSpecifies the password to use in the request.\n"
+            << "\t--skip-verify-peer\tSpecifies if the peer verification should be skipped. Default is false.\n"
             << "\t--timeout TIMEOUT\tSpecifies the timeout in miliseconds for the request.\n"
             << "\nExample:"
             << "\n\t./urlrequest_testtool -u https://httpbin.org/get -t download -o out \n"
@@ -212,6 +224,7 @@ private:
     const std::string m_key;
     const std::string m_username;
     const std::string m_password;
+    const bool m_skipVerifyPeer;
     const long m_timeout;
 };
 

--- a/test_tool/factoryAction.hpp
+++ b/test_tool/factoryAction.hpp
@@ -34,12 +34,14 @@ public:
         std::string sslKey {args.key()};
         std::string username {args.username()};
         std::string password {args.password()};
+        bool skipVerifyPeer {args.skipVerifyPeer()};
 
         auto secureCommunication = SecureCommunication::builder();
         secureCommunication.basicAuth(username + ":" + password)
             .sslCertificate(sslCertificate)
             .sslKey(sslKey)
-            .caRootCertificate(caRootCertificate);
+            .caRootCertificate(caRootCertificate)
+            .skipPeerVerification(skipVerifyPeer);
 
         std::unordered_set<std::string> headers;
         if (args.headers().empty())


### PR DESCRIPTION
## Description

Part of https://github.com/wazuh/wazuh/issues/27174

This PR adds the functionality to make optional the verification of certificates against a CA, also modifies the test tool to verify this behavior.

### Example

Skipping validation against opensearch
```console
╰─# ./urlrequest_testtool -u "https://localhost:9200/_cluster/health?pretty=true" -t get --skip-verify-peer true --username admin --password admin
{
  "cluster_name" : "opensearch-cluster",
  "status" : "green",
  "timed_out" : false,
  "number_of_nodes" : 1,
  "number_of_data_nodes" : 1,
  "discovered_master" : true,
  "discovered_cluster_manager" : true,
  "active_primary_shards" : 5,
  "active_shards" : 5,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 0,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0,
  "task_max_waiting_in_queue_millis" : 0,
  "active_shards_percent_as_number" : 100.0
}
```

Without skipping validation
```bash
(venv) ╭─root@56bc7e709b7a /workspaces/repos/wazuh-http-request/build/test_tool ‹27174-implement-ssl-verification●› 
╰─# ./urlrequest_testtool -u "https://localhost:9200/_cluster/health?pretty=true" -t get --skip-verify-peer false --username admin --password admin
SSL peer certificate or SSH remote key was not OK: -1
SSL peer certificate or SSH remote key was not OK

Usage: urlrequest_testtool <option(s)> SOURCES 
Options:
        -h                      Show this help message
        -u URL_ADDRESS          Specifies the URL of the file to download or the RESTful address.
        -t TYPE                 Specifies the type of action to execute [download, post, get, put, delete].
        -p JSON_FILE            Specifies the file containing the JSON data to send in the POST request.
        -o OUTPUT_FILE          Specifies the output file of the downloaded file.
        -H HEADERS              Specifies the headers to send in the request. If not preset, DEFAULT_HEADERS will be used.
        --cacert CACERT         Specifies the CA certificate file to use in the request.
        --cert CERT             Specifies the certificate file to use in the request.
        --key KEY               Specifies the key file to use in the request.
        --username USERNAME     Specifies the username to use in the request.
        --password PASSWORD     Specifies the password to use in the request.
        --skip-verify-peer      Specifies if the peer verification should be skipped. Default is false.
        --timeout TIMEOUT       Specifies the timeout in miliseconds for the request.

Example:
        ./urlrequest_testtool -u https://httpbin.org/get -t download -o out 

        ./urlrequest_testtool -u https://httpbin.org/get -t get

        ./urlrequest_testtool -u https://httpbin.org/post -t post -p input.json

        ./urlrequest_testtool -u https://httpbin.org/put -t put -p input.json

        ./urlrequest_testtool -u https://httpbin.org/delete -t delete

        ./urlrequest_testtool -u https://httpbin.org/get -t get -H "Authorization: Bearer token"

        ./urlrequest_testtool -u https://httpbin.org/get -t get --cacert cacert.pem --cert cert.pem --key key.pem --username admin --password admin

        ./urlrequest_testtool -u https://httpbin.org/delay/10 -t get --timeout 1000

(venv) ╭─root@56bc7e709b7a /workspaces/repos/wazuh-http-request/build/test_tool ‹27174-implement-ssl-verification●› 
╰─# ./urlrequest_testtool -u "https://localhost:9200/_cluster/health?pretty=true" -t get --username admin --password admin 
SSL peer certificate or SSH remote key was not OK: -1
SSL peer certificate or SSH remote key was not OK

Usage: urlrequest_testtool <option(s)> SOURCES 
Options:
        -h                      Show this help message
        -u URL_ADDRESS          Specifies the URL of the file to download or the RESTful address.
        -t TYPE                 Specifies the type of action to execute [download, post, get, put, delete].
        -p JSON_FILE            Specifies the file containing the JSON data to send in the POST request.
        -o OUTPUT_FILE          Specifies the output file of the downloaded file.
        -H HEADERS              Specifies the headers to send in the request. If not preset, DEFAULT_HEADERS will be used.
        --cacert CACERT         Specifies the CA certificate file to use in the request.
        --cert CERT             Specifies the certificate file to use in the request.
        --key KEY               Specifies the key file to use in the request.
        --username USERNAME     Specifies the username to use in the request.
        --password PASSWORD     Specifies the password to use in the request.
        --skip-verify-peer      Specifies if the peer verification should be skipped. Default is false.
        --timeout TIMEOUT       Specifies the timeout in miliseconds for the request.

Example:
        ./urlrequest_testtool -u https://httpbin.org/get -t download -o out 

        ./urlrequest_testtool -u https://httpbin.org/get -t get

        ./urlrequest_testtool -u https://httpbin.org/post -t post -p input.json

        ./urlrequest_testtool -u https://httpbin.org/put -t put -p input.json

        ./urlrequest_testtool -u https://httpbin.org/delete -t delete

        ./urlrequest_testtool -u https://httpbin.org/get -t get -H "Authorization: Bearer token"

        ./urlrequest_testtool -u https://httpbin.org/get -t get --cacert cacert.pem --cert cert.pem --key key.pem --username admin --password admin

        ./urlrequest_testtool -u https://httpbin.org/delay/10 -t get --timeout 1000

```

With certs:
```
╭─root@56bc7e709b7a /workspaces/repos/wazuh-http-request/build/test_tool ‹27174-implement-ssl-verification› 
╰─# ./urlrequest_testtool -u "https://localhost:9200/_cluster/health?pretty=true" -t get --skip-verify-peer false --username admin --password admin --cert /workspaces/repos/full_environment/certs/wazuh-indexer.pem --cacert /workspaces/repos/full_environment/certs/root-ca.pem --key /workspaces/repos/full_environment/certs/wazuh-indexer.key
{
  "cluster_name" : "opensearch-cluster",
  "status" : "green",
  "timed_out" : false,
  "number_of_nodes" : 1,
  "number_of_data_nodes" : 1,
  "discovered_master" : true,
  "discovered_cluster_manager" : true,
  "active_primary_shards" : 5,
  "active_shards" : 5,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 0,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0,
  "task_max_waiting_in_queue_millis" : 0,
  "active_shards_percent_as_number" : 100.0
}

```

**HTTP**
```
./urlrequest_testtool -u "http://www.http2demo.io/" -t get

<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="utf-8">
    <meta http-equiv="X-Ua-Compatible" content="IE=edge,chrome=1">
    <meta name="viewport" content="width=device-width">
    <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon">
    <title>HTTP/2 technology demo</title>
    <link rel="stylesheet" href="css/style.css" media="all">
    <link rel="stylesheet" href="css/jssocials.css" media="all">
    <link rel="stylesheet" href="css/jssocials-theme-flat.css" media="all">
    <link rel="stylesheet" href="css/font-awesome.css" media="all">
</head>
..........
```