### PR TITLE
Add move support in the response

### DIFF
--- a/.github/workflows/cmake-debug.yml
+++ b/.github/workflows/cmake-debug.yml
@@ -2,9 +2,9 @@ name: CMake-debug
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "1.0.0" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "1.0.0" ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "1.0.0" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "1.0.0" ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/include/HTTPRequest.hpp
+++ b/include/HTTPRequest.hpp
@@ -39,7 +39,8 @@ public:
     void download(std::variant<TRequestParameters<std::string>,
                                TRequestParameters<nlohmann::json>,
                                TRequestParameters<std::string_view>> requestParameters,
-                  PostRequestParameters postRequestParameters = {},
+                  std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                      postRequestParameters = TPostRequestParameters<const std::string&> {},
                   ConfigurationParameters configurationParameters = {});
 
     /**
@@ -52,7 +53,8 @@ public:
     void post(std::variant<TRequestParameters<std::string>,
                            TRequestParameters<nlohmann::json>,
                            TRequestParameters<std::string_view>> requestParameters,
-              PostRequestParameters postRequestParameters = {},
+              std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                  postRequestParameters = TPostRequestParameters<const std::string&> {},
               ConfigurationParameters configurationParameters = {});
 
     /**
@@ -65,7 +67,8 @@ public:
     void get(std::variant<TRequestParameters<std::string>,
                           TRequestParameters<nlohmann::json>,
                           TRequestParameters<std::string_view>> requestParameters,
-             PostRequestParameters postRequestParameters = {},
+             std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                 postRequestParameters = TPostRequestParameters<const std::string&> {},
              ConfigurationParameters configurationParameters = {});
 
     /**
@@ -78,7 +81,8 @@ public:
     void put(std::variant<TRequestParameters<std::string>,
                           TRequestParameters<nlohmann::json>,
                           TRequestParameters<std::string_view>> requestParameters,
-             PostRequestParameters postRequestParameters = {},
+             std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                 postRequestParameters = TPostRequestParameters<const std::string&> {},
              ConfigurationParameters configurationParameters = {});
 
     /**
@@ -91,7 +95,8 @@ public:
     void patch(std::variant<TRequestParameters<std::string>,
                             TRequestParameters<nlohmann::json>,
                             TRequestParameters<std::string_view>> requestParameters,
-               PostRequestParameters postRequestParameters = {},
+               std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                   postRequestParameters = TPostRequestParameters<const std::string&> {},
                ConfigurationParameters configurationParameters = {});
 
     /**
@@ -104,7 +109,8 @@ public:
     void delete_(std::variant<TRequestParameters<std::string>,
                               TRequestParameters<nlohmann::json>,
                               TRequestParameters<std::string_view>> requestParameters,
-                 PostRequestParameters postRequestParameters = {},
+                 std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                     postRequestParameters = TPostRequestParameters<const std::string&> {},
                  ConfigurationParameters configurationParameters = {});
 };
 

--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -198,13 +198,14 @@ struct ConfigurationParameters
  * @brief The structure groups all the parameters related to the actions to be performed after the request is made, like
  * error handling, results processing, etc. They can be thought of as "what to do after".
  */
-struct PostRequestParameters
+template<typename T = const std::string&>
+struct TPostRequestParameters
 {
     /**
      * @brief Callback to be called when the request is successful.
      *
      */
-    std::function<void(const std::string&)> onSuccess = [](auto) {
+    std::function<void(T)> onSuccess = [](auto) {
     };
 
     /**
@@ -219,6 +220,8 @@ struct PostRequestParameters
      */
     const std::string& outputFile = "";
 };
+using PostRequestParameters = TPostRequestParameters<>;
+using PostRequestParametersRValue = TPostRequestParameters<std::string&&>;
 
 /**
  * @brief This class is an interface to perform URL requests.
@@ -238,7 +241,8 @@ public:
     virtual void download(std::variant<TRequestParameters<std::string>,
                                        TRequestParameters<nlohmann::json>,
                                        TRequestParameters<std::string_view>> requestParameters,
-                          PostRequestParameters postRequestParameters,
+                          std::variant<TPostRequestParameters<const std::string&>,
+                                       TPostRequestParameters<std::string&&>> postRequestParameters,
                           ConfigurationParameters configurationParameters) = 0;
 
     /**
@@ -251,7 +255,8 @@ public:
     virtual void post(std::variant<TRequestParameters<std::string>,
                                    TRequestParameters<nlohmann::json>,
                                    TRequestParameters<std::string_view>> requestParameters,
-                      PostRequestParameters postRequestParameters,
+                      std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                          postRequestParameters,
                       ConfigurationParameters configurationParameters) = 0;
 
     /**
@@ -264,7 +269,8 @@ public:
     virtual void get(std::variant<TRequestParameters<std::string>,
                                   TRequestParameters<nlohmann::json>,
                                   TRequestParameters<std::string_view>> requestParameters,
-                     PostRequestParameters postRequestParameters,
+                     std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                         postRequestParameters,
                      ConfigurationParameters configurationParameters) = 0;
 
     /**
@@ -277,7 +283,8 @@ public:
     virtual void put(std::variant<TRequestParameters<std::string>,
                                   TRequestParameters<nlohmann::json>,
                                   TRequestParameters<std::string_view>> requestParameters,
-                     PostRequestParameters postRequestParameters,
+                     std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                         postRequestParameters,
                      ConfigurationParameters configurationParameters) = 0;
 
     /**
@@ -290,7 +297,8 @@ public:
     virtual void patch(std::variant<TRequestParameters<std::string>,
                                     TRequestParameters<nlohmann::json>,
                                     TRequestParameters<std::string_view>> requestParameters,
-                       PostRequestParameters postRequestParameters,
+                       std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                           postRequestParameters,
                        ConfigurationParameters configurationParameters) = 0;
 
     /**
@@ -303,7 +311,8 @@ public:
     virtual void delete_(std::variant<TRequestParameters<std::string>,
                                       TRequestParameters<nlohmann::json>,
                                       TRequestParameters<std::string_view>> requestParameters,
-                         PostRequestParameters postRequestParameters,
+                         std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                             postRequestParameters,
                          ConfigurationParameters configurationParameters) = 0;
 };
 

--- a/include/UNIXSocketRequest.hpp
+++ b/include/UNIXSocketRequest.hpp
@@ -40,7 +40,8 @@ public:
     void download(std::variant<TRequestParameters<std::string>,
                                TRequestParameters<nlohmann::json>,
                                TRequestParameters<std::string_view>> requestParameters,
-                  PostRequestParameters postRequestParameters,
+                  std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                      postRequestParameters,
                   ConfigurationParameters configurationParameters);
     /**
      * @brief Performs a UNIX SOCKET POST request.
@@ -52,7 +53,8 @@ public:
     void post(std::variant<TRequestParameters<std::string>,
                            TRequestParameters<nlohmann::json>,
                            TRequestParameters<std::string_view>> requestParameters,
-              PostRequestParameters postRequestParameters,
+              std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                  postRequestParameters,
               ConfigurationParameters configurationParameters);
 
     /**
@@ -65,7 +67,8 @@ public:
     void get(std::variant<TRequestParameters<std::string>,
                           TRequestParameters<nlohmann::json>,
                           TRequestParameters<std::string_view>> requestParameters,
-             PostRequestParameters postRequestParameters,
+             std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                 postRequestParameters,
              ConfigurationParameters configurationParameters);
     /**
      * @brief Performs a UNIX SOCKET PUT request.
@@ -77,7 +80,8 @@ public:
     void put(std::variant<TRequestParameters<std::string>,
                           TRequestParameters<nlohmann::json>,
                           TRequestParameters<std::string_view>> requestParameters,
-             PostRequestParameters postRequestParameters,
+             std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                 postRequestParameters,
              ConfigurationParameters configurationParameters);
 
     /**
@@ -90,7 +94,8 @@ public:
     void patch(std::variant<TRequestParameters<std::string>,
                             TRequestParameters<nlohmann::json>,
                             TRequestParameters<std::string_view>> requestParameters,
-               PostRequestParameters postRequestParameters,
+               std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                   postRequestParameters,
                ConfigurationParameters configurationParameters);
 
     /**
@@ -103,7 +108,8 @@ public:
     void delete_(std::variant<TRequestParameters<std::string>,
                               TRequestParameters<nlohmann::json>,
                               TRequestParameters<std::string_view>> requestParameters,
-                 PostRequestParameters postRequestParameters,
+                 std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                     postRequestParameters,
                  ConfigurationParameters configurationParameters);
 };
 

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -14,9 +14,7 @@
 #include "factoryRequestImplemetator.hpp"
 #include "json.hpp"
 #include "urlRequest.hpp"
-#include <atomic>
 #include <string>
-#include <unordered_set>
 #include <variant>
 
 using wrapperType = cURLWrapper;

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -24,12 +24,13 @@ using wrapperType = cURLWrapper;
 void HTTPRequest::download(std::variant<TRequestParameters<std::string>,
                                         TRequestParameters<nlohmann::json>,
                                         TRequestParameters<std::string_view>> requestParameters,
-                           PostRequestParameters postRequestParameters,
+                           std::variant<TPostRequestParameters<const std::string&>,
+                                        TPostRequestParameters<std::string&&>> postRequestParameters,
                            ConfigurationParameters configurationParameters)
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -38,10 +39,11 @@ void HTTPRequest::download(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string returnValue;
         std::visit(
             [&](auto&& arg)
             {
-                GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))
+                GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue, handlerType, shouldRun))
                     .url(arg.url.url(), arg.secureCommunication)
                     .outputFile(outputFile)
                     .appendHeaders(arg.httpHeaders)
@@ -78,13 +80,13 @@ void HTTPRequest::download(std::variant<TRequestParameters<std::string>,
 void HTTPRequest::post(std::variant<TRequestParameters<std::string>,
                                     TRequestParameters<nlohmann::json>,
                                     TRequestParameters<std::string_view>> requestParameters,
-                       PostRequestParameters postRequestParameters,
+                       std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                           postRequestParameters,
                        ConfigurationParameters configurationParameters)
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -93,13 +95,15 @@ void HTTPRequest::post(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
                 using T = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
                 {
-                    auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PostRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(arg.data)
                         .appendHeaders(arg.httpHeaders)
@@ -108,11 +112,25 @@ void HTTPRequest::post(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
                 {
-                    auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PostRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<std::string_view>(arg.data)
                         .appendHeaders(arg.httpHeaders)
@@ -121,12 +139,26 @@ void HTTPRequest::post(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
                 {
                     const std::string data = arg.data.dump();
-                    auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PostRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(data)
                         .appendHeaders(arg.httpHeaders)
@@ -135,7 +167,20 @@ void HTTPRequest::post(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else
                 {
@@ -171,13 +216,13 @@ void HTTPRequest::post(std::variant<TRequestParameters<std::string>,
 void HTTPRequest::get(std::variant<TRequestParameters<std::string>,
                                    TRequestParameters<nlohmann::json>,
                                    TRequestParameters<std::string_view>> requestParameters,
-                      PostRequestParameters postRequestParameters,
+                      std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                          postRequestParameters,
                       ConfigurationParameters configurationParameters)
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -186,17 +231,33 @@ void HTTPRequest::get(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
-                auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                auto req {
+                    GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                 req.url(arg.url.url(), arg.secureCommunication)
                     .appendHeaders(arg.httpHeaders)
                     .timeout(timeout)
                     .userAgent(userAgent)
                     .outputFile(outputFile)
                     .execute();
-                onSuccess(req.response());
+
+                std::visit(
+                    [&](auto&& arg)
+                    {
+                        using Tb = std::decay_t<decltype(arg)>;
+                        if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                        {
+                            arg.onSuccess(response);
+                        }
+                        else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                        {
+                            arg.onSuccess(std::move(response));
+                        }
+                    },
+                    postRequestParameters);
             },
             requestParameters);
     }
@@ -227,13 +288,13 @@ void HTTPRequest::get(std::variant<TRequestParameters<std::string>,
 void HTTPRequest::put(std::variant<TRequestParameters<std::string>,
                                    TRequestParameters<nlohmann::json>,
                                    TRequestParameters<std::string_view>> requestParameters,
-                      PostRequestParameters postRequestParameters,
+                      std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                          postRequestParameters,
                       ConfigurationParameters configurationParameters)
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -242,13 +303,15 @@ void HTTPRequest::put(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
                 using T = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
                 {
-                    auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PutRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(arg.data)
                         .appendHeaders(arg.httpHeaders)
@@ -257,11 +320,25 @@ void HTTPRequest::put(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
                 {
-                    auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PutRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<std::string_view>(arg.data)
                         .appendHeaders(arg.httpHeaders)
@@ -270,12 +347,26 @@ void HTTPRequest::put(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
                 {
                     const std::string data = arg.data.dump();
-                    auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PutRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(data)
                         .appendHeaders(arg.httpHeaders)
@@ -284,7 +375,20 @@ void HTTPRequest::put(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else
                 {
@@ -320,13 +424,13 @@ void HTTPRequest::put(std::variant<TRequestParameters<std::string>,
 void HTTPRequest::patch(std::variant<TRequestParameters<std::string>,
                                      TRequestParameters<nlohmann::json>,
                                      TRequestParameters<std::string_view>> requestParameters,
-                        PostRequestParameters postRequestParameters,
+                        std::variant<TPostRequestParameters<const std::string&>, TPostRequestParameters<std::string&&>>
+                            postRequestParameters,
                         ConfigurationParameters configurationParameters)
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -335,14 +439,15 @@ void HTTPRequest::patch(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
                 using T = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
                 {
-                    auto req {
-                        PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PatchRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(arg.data)
                         .appendHeaders(arg.httpHeaders)
@@ -351,12 +456,25 @@ void HTTPRequest::patch(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
                 {
-                    auto req {
-                        PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PatchRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<std::string_view>(arg.data)
                         .appendHeaders(arg.httpHeaders)
@@ -365,13 +483,26 @@ void HTTPRequest::patch(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
                 {
                     const std::string data = arg.data.dump();
-                    auto req {
-                        PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PatchRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(data)
                         .appendHeaders(arg.httpHeaders)
@@ -380,7 +511,20 @@ void HTTPRequest::patch(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else
                 {
@@ -416,13 +560,13 @@ void HTTPRequest::patch(std::variant<TRequestParameters<std::string>,
 void HTTPRequest::delete_(std::variant<TRequestParameters<std::string>,
                                        TRequestParameters<nlohmann::json>,
                                        TRequestParameters<std::string_view>> requestParameters,
-                          PostRequestParameters postRequestParameters,
+                          std::variant<TPostRequestParameters<const std::string&>,
+                                       TPostRequestParameters<std::string&&>> postRequestParameters,
                           ConfigurationParameters configurationParameters)
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -431,10 +575,12 @@ void HTTPRequest::delete_(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
-                auto req {DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                auto req {DeleteRequest::builder(
+                    FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                 req.url(arg.url.url(), arg.secureCommunication)
                     .appendHeaders(arg.httpHeaders)
                     .timeout(timeout)
@@ -442,7 +588,20 @@ void HTTPRequest::delete_(std::variant<TRequestParameters<std::string>,
                     .outputFile(outputFile)
                     .execute();
 
-                onSuccess(req.response());
+                std::visit(
+                    [&](auto&& arg)
+                    {
+                        using Tb = std::decay_t<decltype(arg)>;
+                        if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                        {
+                            arg.onSuccess(response);
+                        }
+                        else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                        {
+                            arg.onSuccess(std::move(response));
+                        }
+                    },
+                    postRequestParameters);
             },
             requestParameters);
     }

--- a/src/IRequestImplementator.hpp
+++ b/src/IRequestImplementator.hpp
@@ -77,12 +77,6 @@ public:
     virtual void execute() = 0;
 
     /**
-     * @brief Virtual method to get the value of the last request.
-     * @return The value of the last request.
-     */
-    virtual inline const std::string response() = 0;
-
-    /**
      * @brief Virtual method to add a header to the handle.
      * @param header The header to be added.
      */

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -21,13 +21,13 @@ using wrapperType = cURLWrapper;
 void UNIXSocketRequest::download(std::variant<TRequestParameters<std::string>,
                                               TRequestParameters<nlohmann::json>,
                                               TRequestParameters<std::string_view>> requestParameters,
-                                 PostRequestParameters postRequestParameters = {},
+                                 std::variant<TPostRequestParameters<const std::string&>,
+                                              TPostRequestParameters<std::string&&>> postRequestParameters = {},
                                  ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -36,10 +36,11 @@ void UNIXSocketRequest::download(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
-                GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))
+                GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))
                     .url(arg.url.url(), arg.secureCommunication)
                     .unixSocketPath(arg.url.unixSocketPath())
                     .timeout(timeout)
@@ -76,13 +77,13 @@ void UNIXSocketRequest::download(std::variant<TRequestParameters<std::string>,
 void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                                           TRequestParameters<nlohmann::json>,
                                           TRequestParameters<std::string_view>> requestParameters,
-                             PostRequestParameters postRequestParameters = {},
+                             std::variant<TPostRequestParameters<const std::string&>,
+                                          TPostRequestParameters<std::string&&>> postRequestParameters = {},
                              ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -91,13 +92,15 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
                 using T = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
                 {
-                    auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PostRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -105,12 +108,25 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                         .template postData<const std::string&>(arg.data)
                         .outputFile(outputFile)
                         .execute();
-
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
                 {
-                    auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PostRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -119,12 +135,26 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
                 {
                     const auto data = arg.data.dump();
-                    auto req {PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PostRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -133,7 +163,20 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else
                 {
@@ -169,13 +212,13 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
 void UNIXSocketRequest::get(std::variant<TRequestParameters<std::string>,
                                          TRequestParameters<nlohmann::json>,
                                          TRequestParameters<std::string_view>> requestParameters,
-                            PostRequestParameters postRequestParameters = {},
+                            std::variant<TPostRequestParameters<const std::string&>,
+                                         TPostRequestParameters<std::string&&>> postRequestParameters = {},
                             ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -184,10 +227,12 @@ void UNIXSocketRequest::get(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
-                auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                auto req {
+                    GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                 req.url(arg.url.url(), arg.secureCommunication)
                     .unixSocketPath(arg.url.unixSocketPath())
                     .timeout(timeout)
@@ -195,7 +240,20 @@ void UNIXSocketRequest::get(std::variant<TRequestParameters<std::string>,
                     .outputFile(outputFile)
                     .execute();
 
-                onSuccess(req.response());
+                std::visit(
+                    [&](auto&& arg)
+                    {
+                        using Tb = std::decay_t<decltype(arg)>;
+                        if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                        {
+                            arg.onSuccess(response);
+                        }
+                        else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                        {
+                            arg.onSuccess(std::move(response));
+                        }
+                    },
+                    postRequestParameters);
             },
             requestParameters);
     }
@@ -226,13 +284,13 @@ void UNIXSocketRequest::get(std::variant<TRequestParameters<std::string>,
 void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                                          TRequestParameters<nlohmann::json>,
                                          TRequestParameters<std::string_view>> requestParameters,
-                            PostRequestParameters postRequestParameters = {},
+                            std::variant<TPostRequestParameters<const std::string&>,
+                                         TPostRequestParameters<std::string&&>> postRequestParameters = {},
                             ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -241,13 +299,15 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
                 using T = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
                 {
-                    auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PutRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -256,11 +316,25 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
                 {
-                    auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PutRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -269,12 +343,26 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
                 {
                     const auto data = arg.data.dump();
-                    auto req {PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PutRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(data)
                         .appendHeaders(arg.httpHeaders)
@@ -283,7 +371,20 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else
                 {
@@ -319,13 +420,13 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
 void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                                            TRequestParameters<nlohmann::json>,
                                            TRequestParameters<std::string_view>> requestParameters,
-                              PostRequestParameters postRequestParameters = {},
+                              std::variant<TPostRequestParameters<const std::string&>,
+                                           TPostRequestParameters<std::string&&>> postRequestParameters = {},
                               ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -334,14 +435,15 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
                 using T = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
                 {
-                    auto req {
-                        PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PatchRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -350,12 +452,25 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
                 {
-                    auto req {
-                        PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PatchRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -364,13 +479,26 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
                 {
                     const auto data = arg.data.dump();
-                    auto req {
-                        PatchRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                    auto req {PatchRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
                         .timeout(timeout)
@@ -379,7 +507,20 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                         .outputFile(outputFile)
                         .execute();
 
-                    onSuccess(req.response());
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
                 }
                 else
                 {
@@ -415,13 +556,13 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
 void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
                                              TRequestParameters<nlohmann::json>,
                                              TRequestParameters<std::string_view>> requestParameters,
-                                PostRequestParameters postRequestParameters = {},
+                                std::variant<TPostRequestParameters<const std::string&>,
+                                             TPostRequestParameters<std::string&&>> postRequestParameters = {},
                                 ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
-    const auto& onError {postRequestParameters.onError};
-    const auto& onSuccess {postRequestParameters.onSuccess};
-    const auto& outputFile {postRequestParameters.outputFile};
+    const auto& onError {std::visit([](auto&& arg) { return arg.onError; }, postRequestParameters)};
+    const auto& outputFile {std::visit([](auto&& arg) { return arg.outputFile; }, postRequestParameters)};
     // Configuration parameters
     const auto& timeout {configurationParameters.timeout};
     const auto& userAgent {configurationParameters.userAgent};
@@ -430,10 +571,12 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
 
     try
     {
+        std::string response;
         std::visit(
             [&](auto&& arg)
             {
-                auto req {DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create(handlerType, shouldRun))};
+                auto req {DeleteRequest::builder(
+                    FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                 req.url(arg.url.url(), arg.secureCommunication)
                     .unixSocketPath(arg.url.unixSocketPath())
                     .timeout(timeout)
@@ -441,7 +584,20 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
                     .outputFile(outputFile)
                     .execute();
 
-                onSuccess(req.response());
+                std::visit(
+                    [&](auto&& arg)
+                    {
+                        using Tb = std::decay_t<decltype(arg)>;
+                        if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                        {
+                            arg.onSuccess(response);
+                        }
+                        else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                        {
+                            arg.onSuccess(std::move(response));
+                        }
+                    },
+                    postRequestParameters);
             },
             requestParameters);
     }

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -12,9 +12,7 @@
 #include "UNIXSocketRequest.hpp"
 #include "factoryRequestImplemetator.hpp"
 #include "urlRequest.hpp"
-#include <atomic>
 #include <string>
-#include <unordered_set>
 
 using wrapperType = cURLWrapper;
 
@@ -22,7 +20,7 @@ void UNIXSocketRequest::download(std::variant<TRequestParameters<std::string>,
                                               TRequestParameters<nlohmann::json>,
                                               TRequestParameters<std::string_view>> requestParameters,
                                  std::variant<TPostRequestParameters<const std::string&>,
-                                              TPostRequestParameters<std::string&&>> postRequestParameters = {},
+                                              TPostRequestParameters<std::string&&>> postRequestParameters,
                                  ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
@@ -78,7 +76,7 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                                           TRequestParameters<nlohmann::json>,
                                           TRequestParameters<std::string_view>> requestParameters,
                              std::variant<TPostRequestParameters<const std::string&>,
-                                          TPostRequestParameters<std::string&&>> postRequestParameters = {},
+                                          TPostRequestParameters<std::string&&>> postRequestParameters,
                              ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
@@ -213,7 +211,7 @@ void UNIXSocketRequest::get(std::variant<TRequestParameters<std::string>,
                                          TRequestParameters<nlohmann::json>,
                                          TRequestParameters<std::string_view>> requestParameters,
                             std::variant<TPostRequestParameters<const std::string&>,
-                                         TPostRequestParameters<std::string&&>> postRequestParameters = {},
+                                         TPostRequestParameters<std::string&&>> postRequestParameters,
                             ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
@@ -285,7 +283,7 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                                          TRequestParameters<nlohmann::json>,
                                          TRequestParameters<std::string_view>> requestParameters,
                             std::variant<TPostRequestParameters<const std::string&>,
-                                         TPostRequestParameters<std::string&&>> postRequestParameters = {},
+                                         TPostRequestParameters<std::string&&>> postRequestParameters,
                             ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
@@ -421,7 +419,7 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                                            TRequestParameters<nlohmann::json>,
                                            TRequestParameters<std::string_view>> requestParameters,
                               std::variant<TPostRequestParameters<const std::string&>,
-                                           TPostRequestParameters<std::string&&>> postRequestParameters = {},
+                                           TPostRequestParameters<std::string&&>> postRequestParameters,
                               ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters
@@ -557,7 +555,7 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
                                              TRequestParameters<nlohmann::json>,
                                              TRequestParameters<std::string_view>> requestParameters,
                                 std::variant<TPostRequestParameters<const std::string&>,
-                                             TPostRequestParameters<std::string&&>> postRequestParameters = {},
+                                             TPostRequestParameters<std::string&&>> postRequestParameters,
                                 ConfigurationParameters configurationParameters = {})
 {
     // Post request parameters

--- a/src/curlSingleHandler.hpp
+++ b/src/curlSingleHandler.hpp
@@ -18,7 +18,6 @@
 #include "customDeleter.hpp"
 #include <memory>
 #include <stdexcept>
-#include <utility>
 
 using deleterCurlHandler = CustomDeleter<decltype(&curl_easy_cleanup), curl_easy_cleanup>;
 

--- a/src/curlWrapper.hpp
+++ b/src/curlWrapper.hpp
@@ -16,16 +16,11 @@
 #include "IRequestImplementator.hpp"
 #include "curl.h"
 #include "curlHandlerCache.hpp"
-#include "curlMultiHandler.hpp"
-#include "curlSingleHandler.hpp"
 #include "customDeleter.hpp"
-#include <algorithm>
 #include <atomic>
 #include <map>
 #include <memory>
-#include <ostream>
 #include <stdexcept>
-#include <thread>
 
 static const std::map<OPTION_REQUEST_TYPE, CURLoption> OPTION_REQUEST_TYPE_MAP = {
     {OPT_URL, CURLOPT_URL},
@@ -44,7 +39,8 @@ static const std::map<OPTION_REQUEST_TYPE, CURLoption> OPTION_REQUEST_TYPE_MAP =
     {OPT_VERIFYPEER, CURLOPT_SSL_VERIFYPEER},
     {OPT_SSL_CERT, CURLOPT_SSLCERT},
     {OPT_SSL_KEY, CURLOPT_SSLKEY},
-    {OPT_BASIC_AUTH, CURLOPT_USERPWD}};
+    {OPT_BASIC_AUTH, CURLOPT_USERPWD},
+};
 
 auto constexpr MAX_REDIRECTIONS {20l};
 
@@ -56,13 +52,30 @@ class cURLWrapper final : public IRequestImplementator
 private:
     using deleterCurlStringList = CustomDeleter<decltype(&curl_slist_free_all), curl_slist_free_all>;
     std::unique_ptr<curl_slist, deleterCurlStringList> m_curlHeaders;
-    std::string& m_returnValue;
     std::shared_ptr<ICURLHandler> m_curlHandler;
+
+    struct ResponseData
+    {
+        double contentLength = 0;
+        std::string& m_returnValue;
+        ICURLHandler* m_curlHandler;
+    };
+    ResponseData m_response;
 
     static size_t writeData(char* data, size_t size, size_t nmemb, void* userdata)
     {
-        const auto str {reinterpret_cast<std::string*>(userdata)};
-        str->append(data, size * nmemb);
+        const auto response {static_cast<ResponseData*>(userdata)};
+        if (response->contentLength == 0)
+        {
+            curl_easy_getinfo(response->m_curlHandler->getHandler().get(),
+                              CURLINFO_CONTENT_LENGTH_DOWNLOAD,
+                              &response->contentLength);
+            if (response->contentLength > 0)
+            {
+                response->m_returnValue.reserve(static_cast<size_t>(response->contentLength));
+            }
+        }
+        response->m_returnValue.append(data, size * nmemb);
         return size * nmemb;
     }
 
@@ -89,7 +102,7 @@ public:
     cURLWrapper(std::string& returnValue,
                 CurlHandlerTypeEnum handlerType = CurlHandlerTypeEnum::SINGLE,
                 const std::atomic<bool>& shouldRun = true)
-        : m_returnValue(returnValue)
+        : m_response {0, returnValue, nullptr}
     {
         m_curlHandler = curlHandlerInit(handlerType, shouldRun);
 
@@ -98,9 +111,11 @@ public:
             throw std::runtime_error("cURL initialization failed");
         }
 
+        m_response.m_curlHandler = m_curlHandler.get();
+
         this->setOptionPtr(OPT_WRITEFUNCTION, reinterpret_cast<void*>(cURLWrapper::writeData));
 
-        this->setOptionPtr(OPT_WRITEDATA, &m_returnValue);
+        this->setOptionPtr(OPT_WRITEDATA, &m_response);
 
         this->setOptionLong(OPT_FAILONERROR, 1l);
 

--- a/src/curlWrapper.hpp
+++ b/src/curlWrapper.hpp
@@ -56,7 +56,7 @@ class cURLWrapper final : public IRequestImplementator
 private:
     using deleterCurlStringList = CustomDeleter<decltype(&curl_slist_free_all), curl_slist_free_all>;
     std::unique_ptr<curl_slist, deleterCurlStringList> m_curlHeaders;
-    std::string m_returnValue;
+    std::string& m_returnValue;
     std::shared_ptr<ICURLHandler> m_curlHandler;
 
     static size_t writeData(char* data, size_t size, size_t nmemb, void* userdata)
@@ -86,8 +86,10 @@ public:
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the handler.
      */
-    cURLWrapper(CurlHandlerTypeEnum handlerType = CurlHandlerTypeEnum::SINGLE,
+    cURLWrapper(std::string& returnValue,
+                CurlHandlerTypeEnum handlerType = CurlHandlerTypeEnum::SINGLE,
                 const std::atomic<bool>& shouldRun = true)
+        : m_returnValue(returnValue)
     {
         m_curlHandler = curlHandlerInit(handlerType, shouldRun);
 
@@ -108,15 +110,6 @@ public:
     }
 
     virtual ~cURLWrapper() = default;
-
-    /**
-     * @brief This method returns the value of the last request.
-     * @return The value of the last request.
-     */
-    inline const std::string response() override
-    {
-        return m_returnValue;
-    }
 
     /**
      * @brief This method sets an option to the curl handler.

--- a/src/factoryRequestImplemetator.hpp
+++ b/src/factoryRequestImplemetator.hpp
@@ -50,14 +50,16 @@ public:
     /**
      * @brief Create a cURLRequest with the corresponding CurlHandlerTypeEnum for the given enum.
      *
+     * @param returnValue Reference to the string that will contain the response.
      * @param handlerType Type of the cURL handler. Default is 'SINGLE'.
      * @param shouldRun Flag used to interrupt the cURL handler.
      * @return A shared pointer to a cURLRequest.
      */
-    static std::shared_ptr<IRequestImplementator> create(CurlHandlerTypeEnum handlerType = CurlHandlerTypeEnum::SINGLE,
+    static std::shared_ptr<IRequestImplementator> create(std::string& returnValue,
+                                                         CurlHandlerTypeEnum handlerType = CurlHandlerTypeEnum::SINGLE,
                                                          const std::atomic<bool>& shouldRun = true)
     {
-        return std::make_shared<cURLWrapper>(handlerType, shouldRun);
+        return std::make_shared<cURLWrapper>(returnValue, handlerType, shouldRun);
     }
 };
 

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -16,10 +16,8 @@
 #include "builder.hpp"
 #include "customDeleter.hpp"
 #include "fsWrapper.hpp"
-#include "json.hpp"
 #include "secureCommunication.hpp"
 #include <algorithm>
-#include <functional>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -130,14 +130,6 @@ public:
     }
 
     /**
-     * @brief This method returns the response.
-     */
-    inline const std::string response() const
-    {
-        return m_requestImplementator->response();
-    }
-
-    /**
      * @brief This method sets the unix socket path and returns a reference to the object.
      * @param sock Unix socket path.
      * @return A reference to the object.

--- a/test/component/CMakeLists.txt
+++ b/test/component/CMakeLists.txt
@@ -5,8 +5,8 @@ file(GLOB URL_REQUEST_COMPONENT_TEST_SRC *.cpp)
 
 add_executable(urlrequest_component_test ${URL_REQUEST_COMPONENT_TEST_SRC})
 
-#target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
-#target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
+target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
+target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
 
 target_link_libraries(urlrequest_component_test urlrequest
     gtest

--- a/test/component/CMakeLists.txt
+++ b/test/component/CMakeLists.txt
@@ -5,8 +5,8 @@ file(GLOB URL_REQUEST_COMPONENT_TEST_SRC *.cpp)
 
 add_executable(urlrequest_component_test ${URL_REQUEST_COMPONENT_TEST_SRC})
 
-target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
-target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
+#target_compile_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
+#target_link_options(urlrequest_component_test PUBLIC "-fsanitize=address,leak,undefined")
 
 target_link_libraries(urlrequest_component_test urlrequest
     gtest

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -1517,7 +1517,7 @@ TEST_F(ComponentTestInterface, PostTestTimeoutMultiHandler)
 TEST_F(ComponentTestInterface, Post100Mbs)
 {
     constexpr uint64_t TEST_SIZE = {100 * 1024 * 1024};
-    constexpr uint64_t SERVER_RSS_USAGE = {5 * 1024};
+    constexpr uint64_t SERVER_RSS_USAGE = {150 * 1024};
     const auto data = std::string(TEST_SIZE, 'a');
     const auto prePost = getMemoryUsedByTheCurrentProcess();
 

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -572,7 +572,11 @@ TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl)
 {
     try
     {
-        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create()).url("").outputFile(TEST_FILE_1).execute();
+        std::string returnValue;
+        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))
+            .url("")
+            .outputFile(TEST_FILE_1)
+            .execute();
     }
     catch (const std::exception& ex)
     {
@@ -589,7 +593,8 @@ TEST_F(ComponentTestInternalParameters, DownloadFileEmptyInvalidUrl2)
 {
     try
     {
-        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+        std::string returnValue;
+        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))
             .url("http://")
             .outputFile(TEST_FILE_1)
             .execute();
@@ -609,7 +614,8 @@ TEST_F(ComponentTestInternalParameters, GetError)
 {
     try
     {
-        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+        std::string returnValue;
+        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))
             .url("http://localhost:44441/invalid_file")
             .execute();
     }
@@ -628,7 +634,8 @@ TEST_F(ComponentTestInternalParameters, PostError)
 {
     try
     {
-        PostRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+        std::string returnValue;
+        PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))
             .url("http://localhost:44441/invalid_file")
             .postData<const std::string&>(R"({"hello":"world"})")
             .execute();
@@ -648,7 +655,8 @@ TEST_F(ComponentTestInternalParameters, PutError)
 {
     try
     {
-        PutRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+        std::string returnValue;
+        PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))
             .url("http://localhost:44441/invalid_file")
             .postData<const std::string&>(R"({"hello":"world"})")
             .execute();
@@ -668,7 +676,8 @@ TEST_F(ComponentTestInternalParameters, DeleteError)
 {
     try
     {
-        DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create())
+        std::string returnValue;
+        DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))
             .url("http://localhost:44441/invalid_file")
             .execute();
     }
@@ -687,7 +696,8 @@ TEST_F(ComponentTestInternalParameters, ExecuteGetNoUrl)
 {
     try
     {
-        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create()).execute();
+        std::string returnValue;
+        GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue)).execute();
     }
     catch (const std::exception& ex)
     {
@@ -704,7 +714,8 @@ TEST_F(ComponentTestInternalParameters, ExecutePostNoUrl)
 {
     try
     {
-        PostRequest::builder(FactoryRequestWrapper<wrapperType>::create()).execute();
+        std::string returnValue;
+        PostRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue)).execute();
     }
     catch (const std::exception& ex)
     {
@@ -721,7 +732,8 @@ TEST_F(ComponentTestInternalParameters, ExecutePutNoUrl)
 {
     try
     {
-        PutRequest::builder(FactoryRequestWrapper<wrapperType>::create()).execute();
+        std::string returnValue;
+        PutRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue)).execute();
     }
     catch (const std::exception& ex)
     {
@@ -738,7 +750,8 @@ TEST_F(ComponentTestInternalParameters, ExecuteDeleteNoUrl)
 {
     try
     {
-        DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create()).execute();
+        std::string returnValue;
+        DeleteRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue)).execute();
     }
     catch (const std::exception& ex)
     {
@@ -765,11 +778,12 @@ TEST_F(ComponentTestInternalParameters, MultipleThreads)
             {
                 do
                 {
+                    std::string returnValue;
                     EXPECT_NO_THROW({
-                        auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create())};
+                        auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(returnValue))};
                         req.url("http://localhost:44441/").execute();
 
-                        EXPECT_STREQ(req.response().c_str(), "Hello World!");
+                        EXPECT_STREQ(returnValue.c_str(), "Hello World!");
                     });
                 } while (!stopTest.load());
             });
@@ -803,12 +817,13 @@ TEST_F(ComponentTestInternalParameters, MultipleThreadsWithMultiHandlers)
             {
                 do
                 {
+                    std::string response;
                     EXPECT_NO_THROW({
-                        auto req {GetRequest::builder(
-                            FactoryRequestWrapper<wrapperType>::create(CurlHandlerTypeEnum::MULTI, m_shouldRun))};
+                        auto req {GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(
+                            response, CurlHandlerTypeEnum::MULTI, m_shouldRun))};
                         req.url("http://localhost:44441/").execute();
 
-                        EXPECT_STREQ(req.response().c_str(), "Hello World!");
+                        EXPECT_STREQ(response.c_str(), "Hello World!");
                     });
                 } while (!stopTest.load());
             });
@@ -1534,9 +1549,6 @@ TEST_F(ComponentTestInterface, Post100MbsStringView)
                                                             m_callbackComplete = true;
                                                         }});
     const auto postPost = getMemoryUsedByTheCurrentProcess();
-    std::cout << " Post post: " << postPost << std::endl;
-    std::cout << " Pre post: " << prePost << std::endl;
-    std::cout << " Server RSS usage: " << SERVER_RSS_USAGE << std::endl;
 
     EXPECT_LE(postPost, prePost + SERVER_RSS_USAGE);
 }

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -1517,8 +1517,7 @@ TEST_F(ComponentTestInterface, PostTestTimeoutMultiHandler)
 TEST_F(ComponentTestInterface, Post100Mbs)
 {
     constexpr uint64_t TEST_SIZE = {100 * 1024 * 1024};
-    // Simulate a server RSS usage of 3 times the size of the data
-    constexpr uint64_t SERVER_RSS_USAGE = {(TEST_SIZE * 3) / 1024};
+    constexpr uint64_t SERVER_RSS_USAGE = {5 * 1024};
     const auto data = std::string(TEST_SIZE, 'a');
     const auto prePost = getMemoryUsedByTheCurrentProcess();
 
@@ -1527,6 +1526,7 @@ TEST_F(ComponentTestInterface, Post100Mbs)
                                                         {
                                                             m_callbackComplete = true;
                                                         }});
+    fakeFileServer.reset();
     const auto postPost = getMemoryUsedByTheCurrentProcess();
 
     EXPECT_LE(postPost, prePost + SERVER_RSS_USAGE);
@@ -1538,8 +1538,7 @@ TEST_F(ComponentTestInterface, Post100Mbs)
 TEST_F(ComponentTestInterface, Post100MbsStringView)
 {
     constexpr uint64_t TEST_SIZE = {100 * 1024 * 1024};
-    // Simulate a server RSS usage of 3 times the size of the data
-    constexpr uint64_t SERVER_RSS_USAGE = {(TEST_SIZE * 3) / 1024};
+    constexpr uint64_t SERVER_RSS_USAGE = {5 * 1024};
     const auto data = std::string(TEST_SIZE, 'a');
     const auto prePost = getMemoryUsedByTheCurrentProcess();
 
@@ -1548,6 +1547,7 @@ TEST_F(ComponentTestInterface, Post100MbsStringView)
                                                         {
                                                             m_callbackComplete = true;
                                                         }});
+    fakeFileServer.reset();
     const auto postPost = getMemoryUsedByTheCurrentProcess();
 
     EXPECT_LE(postPost, prePost + SERVER_RSS_USAGE);

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -19,11 +19,17 @@
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <signal.h>
+#include <stdexcept>
 #include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 
 auto constexpr TEST_FILE_1 {"test1.txt"};
 auto constexpr TEST_FILE_2 {"test2.txt"};
+auto constexpr SERVER_PID_FILE {"fake_server.pid"};
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
@@ -34,37 +40,129 @@ auto constexpr TEST_FILE_2 {"test2.txt"};
 
 /**
  * @brief This class is a simple HTTP server that provides a simple interface to perform HTTP requests.
+ * The server runs in a separate process using fork() to avoid memory fragmentation issues.
  */
 namespace
 {
 class FakeServer final
 {
 private:
-    httplib::Server m_server;
-    std::thread m_thread;
+    pid_t m_server_pid;
+    bool m_is_running;
 
 public:
     FakeServer()
-        : m_thread(&FakeServer::run, this)
+        : m_server_pid(-1)
+        , m_is_running(false)
     {
-        // Wait until server is ready
-        while (!m_server.is_running())
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
+        startServer();
     }
 
     ~FakeServer()
     {
-        m_server.stop();
-        m_thread.join();
+        stopServer();
     }
 
     /**
-     * @brief This method is used to start the server.
+     * @brief Start the server in a separate process
      */
-    void run()
+    void startServer()
     {
+        m_server_pid = fork();
+
+        if (m_server_pid == 0)
+        {
+            // Child process - run the server
+            runServer();
+            exit(0);
+        }
+        else if (m_server_pid > 0)
+        {
+            // Parent process - wait for server to be ready
+            waitForServerReady();
+            m_is_running = true;
+        }
+        else
+        {
+            // Fork failed
+            throw std::runtime_error("Failed to fork server process");
+        }
+    }
+
+    /**
+     * @brief Stop the server process
+     */
+    void stopServer()
+    {
+        if (m_server_pid > 0 && m_is_running)
+        {
+            kill(m_server_pid, SIGTERM);
+
+            // Wait for the process to terminate
+            int status;
+            waitpid(m_server_pid, &status, 0);
+
+            // Clean up PID file
+            std::filesystem::remove(SERVER_PID_FILE);
+
+            m_is_running = false;
+            m_server_pid = -1;
+        }
+    }
+
+    /**
+     * @brief Check if server is running
+     */
+    bool isRunning() const
+    {
+        return m_is_running && m_server_pid > 0;
+    }
+
+private:
+    /**
+     * @brief Wait for the server to be ready by checking if it's listening on the port
+     */
+    void waitForServerReady()
+    {
+        const int max_attempts = 100;
+        int attempts = 0;
+
+        httplib::Client client("localhost", 44441);
+        client.set_connection_timeout(1); // 1 second timeout
+
+        while (attempts < max_attempts)
+        {
+            auto result = client.Get("/");
+            if (result && result->status == 200)
+            {
+                break; // Server is ready
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            attempts++;
+        }
+
+        if (attempts >= max_attempts)
+        {
+            throw std::runtime_error("Server failed to start within timeout");
+        }
+    }
+
+    /**
+     * @brief This method runs the server in the child process
+     */
+    void runServer()
+    {
+        // Write PID to file for cleanup
+        std::ofstream pid_file(SERVER_PID_FILE);
+        if (pid_file.is_open())
+        {
+            pid_file << getpid();
+            pid_file.close();
+        }
+
+        httplib::Server server;
+
         // Lambda that returns a JSON holding all headers within a request.
         // For example, if the request has the headers "Key-1: Value-1" and "Key-2: Value-2",
         // this lambda will return the JSON '{"Key-1":"Value-1","Key-2":"Value-2"}'.
@@ -77,69 +175,69 @@ public:
             return httpHeaders;
         };
 
-        m_server.Get("/",
-                     [](const httplib::Request& /*req*/, httplib::Response& res)
-                     { res.set_content("Hello World!", "text/json"); });
+        server.Get("/",
+                   [](const httplib::Request& /*req*/, httplib::Response& res)
+                   { res.set_content("Hello World!", "text/json"); });
 
-        m_server.Get("/redirect",
-                     [](const httplib::Request& /*req*/, httplib::Response& res)
-                     { res.set_redirect("http://localhost:44441/", 301); });
+        server.Get("/redirect",
+                   [](const httplib::Request& /*req*/, httplib::Response& res)
+                   { res.set_redirect("http://localhost:44441/", 301); });
 
-        m_server.Get("/check-headers",
+        server.Get("/check-headers",
+                   [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
+                   { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
+
+        server.Post(
+            "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
+
+        server.Post("/check-headers",
+                    [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
+                    { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
+
+        server.Put("/",
+                   [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
+
+        server.Put("/check-headers",
+                   [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
+                   { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
+
+        server.Patch("/",
+                     [](const httplib::Request& req, httplib::Response& res)
+                     {
+                         nlohmann::json response;
+                         response["query"] = "patch";
+                         response["payload"] = nlohmann::json::parse(req.body);
+
+                         res.set_content(response.dump(), "text/json");
+                     });
+
+        server.Patch("/check-headers",
                      [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
                      { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
 
-        m_server.Post(
-            "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
+        // This endpoint helps simulate the waiting time during an HTTP request.
+        server.Get(R"(/sleep/(\d+))",
+                   [](const httplib::Request& req, httplib::Response& res)
+                   {
+                       auto sleepInterval = std::stoi(req.matches[1]);
+                       std::this_thread::sleep_for(std::chrono::milliseconds(sleepInterval));
+                       res.set_content("Hello World!", "text/json");
+                   });
 
-        m_server.Post("/check-headers",
+        server.Get("/check-headers",
+                   [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
+                   { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
+
+        server.Delete(R"(/(\d+))",
+                      [](const httplib::Request& req, httplib::Response& res)
+                      { res.set_content(req.matches[1], "text/json"); });
+
+        server.Delete("/check-headers",
                       [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
                       { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
 
-        m_server.Put(
-            "/", [](const httplib::Request& req, httplib::Response& res) { res.set_content(req.body, "text/json"); });
-
-        m_server.Put("/check-headers",
-                     [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
-                     { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
-
-        m_server.Patch("/",
-                       [](const httplib::Request& req, httplib::Response& res)
-                       {
-                           nlohmann::json response;
-                           response["query"] = "patch";
-                           response["payload"] = nlohmann::json::parse(req.body);
-
-                           res.set_content(response.dump(), "text/json");
-                       });
-
-        m_server.Patch("/check-headers",
-                       [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
-                       { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
-
-        // This endpoint helps simulate the waiting time during an HTTP request.
-        m_server.Get(R"(/sleep/(\d+))",
-                     [](const httplib::Request& req, httplib::Response& res)
-                     {
-                         auto sleepInterval = std::stoi(req.matches[1]);
-                         std::this_thread::sleep_for(std::chrono::milliseconds(sleepInterval));
-                         res.set_content("Hello World!", "text/json");
-                     });
-
-        m_server.Get("/check-headers",
-                     [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
-                     { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
-
-        m_server.Delete(R"(/(\d+))",
-                        [](const httplib::Request& req, httplib::Response& res)
-                        { res.set_content(req.matches[1], "text/json"); });
-
-        m_server.Delete("/check-headers",
-                        [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
-                        { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
-
-        m_server.set_keep_alive_max_count(1);
-        m_server.listen("localhost", 44441);
+        server.set_keep_alive_max_count(1);
+        server.listen("localhost", 44441);
     }
 };
 } // namespace
@@ -164,8 +262,10 @@ protected:
     /**
      * @brief This method is called before each test to initialize the test environment.
      */
+
     void SetUp() override
     {
+        fakeFileServer.reset(new FakeServer());
         m_callbackComplete = false;
         m_shouldRun.store(true);
     }
@@ -186,25 +286,6 @@ protected:
      * @brief This variable is used to store the server instance.
      */
     inline static std::unique_ptr<FakeServer> fakeFileServer;
-
-    /**
-     * @brief This method is called before each test to initialize the test environment.
-     */
-    static void SetUpTestSuite()
-    {
-        if (!fakeFileServer)
-        {
-            fakeFileServer = std::make_unique<FakeServer>();
-        }
-    }
-
-    /**
-     * @brief This method is called after each test to cleanup the test environment.
-     */
-    static void TearDownTestSuite()
-    {
-        fakeFileServer.reset();
-    }
 };
 
 /**

--- a/test/unit/mocks/MockRequestImplementator.hpp
+++ b/test/unit/mocks/MockRequestImplementator.hpp
@@ -44,10 +44,6 @@ public:
      */
     MOCK_METHOD(void, execute, (), (override));
     /**
-     * @brief Mock method to get the response.
-     */
-    MOCK_METHOD(const std::string, response, (), (override));
-    /**
      * @brief Mock method to append a header.
      */
     MOCK_METHOD(void, appendHeader, (const std::string& header), (override));

--- a/test/unit/unit_test.cpp
+++ b/test/unit/unit_test.cpp
@@ -31,7 +31,6 @@ constexpr OPTION_REQUEST_TYPE optVerifyPeer {OPT_VERIFYPEER};
 constexpr OPTION_REQUEST_TYPE optSslCert {OPT_SSL_CERT};
 constexpr OPTION_REQUEST_TYPE optSslKey {OPT_SSL_KEY};
 constexpr OPTION_REQUEST_TYPE optBasicAuth {OPT_BASIC_AUTH};
-constexpr long zero {0};
 
 /**
  * @brief This test checks the HTTP request.
@@ -43,7 +42,7 @@ TEST_F(UrlRequestUnitTest, GetFileHttp)
     EXPECT_CALL(*request, setOptionString(optUrl, "http://www.wazuh.com/")).Times(1);
     EXPECT_CALL(*request, setOptionString(optCustomRequest, "GET")).Times(1);
     EXPECT_CALL(*request, setOptionPtr(optWriteData, SafeMatcherCast<void*>(_))).Times(1);
-    EXPECT_CALL(*request, setOptionLong(optWriteFunction, zero)).Times(1);
+    EXPECT_CALL(*request, setOptionLong(optWriteFunction, 0)).Times(1);
     EXPECT_CALL(*request, execute()).Times(1);
     EXPECT_CALL(*request, appendHeader(_)).Times(0);
 
@@ -130,7 +129,7 @@ TEST_F(UrlRequestUnitTest, GetFileWithUnixSocket)
     EXPECT_CALL(*request, setOptionString(optUrl, "http://www.wazuh.com/")).Times(1);
     EXPECT_CALL(*request, setOptionString(optCustomRequest, "GET")).Times(1);
     EXPECT_CALL(*request, setOptionPtr(optWriteData, SafeMatcherCast<void*>(_))).Times(1);
-    EXPECT_CALL(*request, setOptionLong(optWriteFunction, zero)).Times(1);
+    EXPECT_CALL(*request, setOptionLong(optWriteFunction, 0)).Times(1);
     EXPECT_CALL(*request, execute()).Times(1);
     EXPECT_CALL(*request, appendHeader(_)).Times(0);
 


### PR DESCRIPTION
## Summary

This commit implements move semantics support for HTTP request responses, allowing for more efficient memory management and performance optimization when handling response data.

## Changes

- **Modified `PostRequestParameters` structure**: Converted to template `TPostRequestParameters` to support both lvalue and rvalue references
- **Updated HTTP request methods**: All HTTP methods (GET, POST, PUT, PATCH, DELETE, DOWNLOAD) now accept moveable response parameters
- **Enhanced type safety**: Added support for `std::string&&` (rvalue) and `const std::string&` (lvalue) response handling
- **Improved memory efficiency**: Responses can now be moved instead of copied when appropriate

## Technical Details

- Introduced `TPostRequestParameters<T>` template with default type `const std::string&`
- Added `PostRequestParametersRValue` type alias for `TPostRequestParameters<std::string&&>`
- Updated method signatures across HTTP request classes to use variant types for post-request parameters
- Modified both HTTP and UNIX socket request implementations
- Updated test files to accommodate new parameter types

## Files Modified

- `include/HTTPRequest.hpp` - Updated method signatures
- `include/IURLRequest.hpp` - Template structure definition
- `include/UNIXSocketRequest.hpp` - Method signature updates
- `src/HTTPRequest.cpp` - Implementation changes
- `src/UNIXSocketRequest.cpp` - Implementation changes
- `src/curlWrapper.hpp` - Interface updates
- `src/factoryRequestImplemetator.hpp` - Factory updates
- `src/urlRequest.hpp` - Interface cleanup
- `src/IRequestImplementator.hpp` - Interface cleanup
- `test/component/component_test.cpp` - Test updates
- `test/unit/mocks/MockRequestImplementator.hpp` - Mock updates
- `test/unit/unit_test.cpp` - Unit test updates

## Impact

This change improves performance by reducing unnecessary string copies and provides more flexible response handling options for consumers of the HTTP request library.