### PR TITLE
Refactor cURL error handling to preserve response data

### DIFF
--- a/shared/curlException.hpp
+++ b/shared/curlException.hpp
@@ -18,58 +18,74 @@
 
 namespace Curl
 {
+/**
+ * @brief Custom exception for Curl wrapper.
+ *
+ */
+class CurlException : public std::exception
+{
+public:
     /**
-     * @brief Custom exception for Curl wrapper.
+     * @brief Returns HTTP response code ID.
      *
+     * @return long HTTP response code ID.
      */
-    class CurlException : public std::exception
+    long responseCode() const noexcept
     {
-        public:
-            /**
-             * @brief Returns HTTP response code ID.
-             *
-             * @return long HTTP response code ID.
-             */
-            long responseCode() const noexcept
-            {
-                return m_responseCode;
-            }
+        return m_responseCode;
+    }
 
-            /**
-             * @brief Return error message.
-             *
-             * @return const char* Error message.
-             */
-            const char* what() const noexcept override
-            {
-                return m_error.what();
-            }
+    /**
+     * @brief Returns HTTP response body.
+     *
+     * @return const std::string& HTTP response body.
+     */
+    const std::string& responseBody() const noexcept
+    {
+        return m_responseBody;
+    }
 
-            /**
-             * @brief Construct a new Curl Exception object
-             *
-             * @param errorMessage Error message to show.
-             * @param responseCode HTTP response code ID.
-             */
-            CurlException(const std::string& errorMessage, const long responseCode)
-                : m_error {errorMessage}
-                , m_responseCode {responseCode}
-            {}
+    /**
+     * @brief Return error message.
+     *
+     * @return const char* Error message.
+     */
+    const char* what() const noexcept override
+    {
+        return m_error.what();
+    }
 
-            /**
-             * @brief Construct a new Curl Exception object
-             *
-             * @param curlException Pair object with an error message and a response code ID.
-             */
-            explicit CurlException(const std::pair<const std::string&, const long>& curlException)
-                : m_error {curlException.first}
-                , m_responseCode {curlException.second}
-            {}
+    /**
+     * @brief Construct a new Curl Exception object
+     *
+     * @param errorMessage Error message to show.
+     * @param responseCode HTTP response code ID.
+     * @param responseBody HTTP response body (optional).
+     */
+    CurlException(const std::string& errorMessage, const long responseCode, std::string responseBody = "")
+        : m_error {errorMessage}
+        , m_responseCode {responseCode}
+        , m_responseBody {std::move(responseBody)}
+    {
+    }
 
-        private:
-            std::runtime_error m_error;
-            const long m_responseCode;
-    };
-}
+    /**
+     * @brief Construct a new Curl Exception object
+     *
+     * @param curlException Pair object with an error message and a response code ID.
+     */
+    explicit CurlException(const std::pair<const std::string&, const long>& curlException)
+        : m_error {curlException.first}
+        , m_responseCode {curlException.second}
+        , m_responseBody {}
+    {
+    }
+
+private:
+    std::runtime_error m_error;
+    const long m_responseCode;
+    const std::string m_responseBody;
+};
+} // namespace Curl
 
 #endif // _CURL_EXCEPTION_HPP

--- a/src/curlSingleHandler.hpp
+++ b/src/curlSingleHandler.hpp
@@ -63,11 +63,11 @@ public:
             {
                 if (resGetInfo != CURLE_OK)
                 {
-                    throw std::runtime_error("cURLSingleHandler::execute() failed: Couldn't get HTTP response code");
+                    throw Curl::CurlException("cURLSingleHandler::execute() failed", NOT_USED);
                 }
                 throw Curl::CurlException(curl_easy_strerror(resPerform), responseCode);
             }
-            throw std::runtime_error(curl_easy_strerror(resPerform));
+            throw Curl::CurlException(curl_easy_strerror(resPerform), NOT_USED);
         }
     }
 };

--- a/src/curlSingleHandler.hpp
+++ b/src/curlSingleHandler.hpp
@@ -53,7 +53,8 @@ public:
         long responseCode;
         const auto resGetInfo {curl_easy_getinfo(m_curlHandler.get(), CURLINFO_RESPONSE_CODE, &responseCode)};
 
-        curl_easy_reset(m_curlHandler.get());
+        // DON'T reset here anymore
+        // curl_easy_reset(m_curlHandler.get());
 
         if (resPerform != CURLE_OK)
         {
@@ -63,10 +64,14 @@ public:
                 {
                     throw std::runtime_error("cURLSingleHandler::execute() failed: Couldn't get HTTP response code");
                 }
+                // Throw exception WITHOUT resetting - response data is still available
                 throw Curl::CurlException(curl_easy_strerror(resPerform), responseCode);
             }
             throw std::runtime_error(curl_easy_strerror(resPerform));
         }
+
+        // Only reset on success
+        curl_easy_reset(m_curlHandler.get());
     }
 };
 

--- a/src/curlSingleHandler.hpp
+++ b/src/curlSingleHandler.hpp
@@ -19,6 +19,8 @@
 #include <memory>
 #include <stdexcept>
 
+constexpr auto NOT_USED {-1};
+
 using deleterCurlHandler = CustomDeleter<decltype(&curl_easy_cleanup), curl_easy_cleanup>;
 
 //! cURLSingleHandler class
@@ -50,11 +52,10 @@ public:
     {
         const auto resPerform {curl_easy_perform(m_curlHandler.get())};
 
-        long responseCode;
+        long responseCode = NOT_USED;
         const auto resGetInfo {curl_easy_getinfo(m_curlHandler.get(), CURLINFO_RESPONSE_CODE, &responseCode)};
 
-        // DON'T reset here anymore
-        // curl_easy_reset(m_curlHandler.get());
+        curl_easy_reset(m_curlHandler.get());
 
         if (resPerform != CURLE_OK)
         {
@@ -64,14 +65,10 @@ public:
                 {
                     throw std::runtime_error("cURLSingleHandler::execute() failed: Couldn't get HTTP response code");
                 }
-                // Throw exception WITHOUT resetting - response data is still available
                 throw Curl::CurlException(curl_easy_strerror(resPerform), responseCode);
             }
             throw std::runtime_error(curl_easy_strerror(resPerform));
         }
-
-        // Only reset on success
-        curl_easy_reset(m_curlHandler.get());
     }
 };
 

--- a/src/curlWrapper.hpp
+++ b/src/curlWrapper.hpp
@@ -117,7 +117,11 @@ public:
 
         this->setOptionPtr(OPT_WRITEDATA, &m_response);
 
-        this->setOptionLong(OPT_FAILONERROR, 1l);
+        // this->setOptionLong(OPT_FAILONERROR, 1l);
+
+        // Note: The OPT_FAILONERROR option makes cURL fail on HTTP response codes >= 400.
+        // However, in such cases we want to capture the response body, so we don't set it.
+        // Instead, we handle HTTP errors in the execute() method.
 
         this->setOptionLong(OPT_FOLLOW_REDIRECT, 1l);
 
@@ -216,7 +220,15 @@ public:
             throw std::runtime_error("cURLWrapper::execute() failed: Couldn't set HTTP headers");
         }
 
-        m_curlHandler->execute();
+        try
+        {
+            m_curlHandler->execute();
+        }
+        catch (Curl::CurlException& ex)
+        {
+            // Note: m_returnValue contains the response body, even for errors
+            throw Curl::CurlException(ex.what(), ex.responseCode(), m_response.m_returnValue);
+        }
     }
 };
 

--- a/src/curlWrapper.hpp
+++ b/src/curlWrapper.hpp
@@ -119,9 +119,10 @@ public:
 
         // this->setOptionLong(OPT_FAILONERROR, 1l);
 
-        // Note: The OPT_FAILONERROR option makes cURL fail on HTTP response codes >= 400.
-        // However, in such cases we want to capture the response body, so we don't set it.
-        // Instead, we handle HTTP errors in the execute() method.
+        // Note: OPT_FAILONERROR is intentionally NOT set. This option would cause cURL
+        // to fail automatically on HTTP response codes >= 400, preventing us from
+        // capturing the response body. We want to allow callers to handle HTTP errors
+        // with full access to the server's response.
 
         this->setOptionLong(OPT_FOLLOW_REDIRECT, 1l);
 
@@ -226,7 +227,8 @@ public:
         }
         catch (Curl::CurlException& ex)
         {
-            // Note: m_returnValue contains the response body, even for errors
+            // Note: m_returnValue contains the response body, even for errors. Could be empty if
+            // the server didn't send any body.
             throw Curl::CurlException(ex.what(), ex.responseCode(), m_response.m_returnValue);
         }
     }

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -214,7 +214,7 @@ TEST_F(ComponentTestInterface, DownloadFileError)
                                                             },
                                                             .outputFile = TEST_FILE_1});
 
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
     checkEmptyFile(TEST_FILE_1);
 }
 
@@ -269,7 +269,7 @@ TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheSingleHandler)
                                                             .outputFile = TEST_FILE_1},
                                      ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::SINGLE});
 
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
     checkEmptyFile(TEST_FILE_1);
 }
 
@@ -383,7 +383,7 @@ TEST_F(ComponentTestInterface, DownloadFileErrorUsingTheMultiHandler)
                                .outputFile = TEST_FILE_1},
         ConfigurationParameters {.handlerType = CurlHandlerTypeEnum::MULTI, .shouldRun = m_shouldRun});
 
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
     checkEmptyFile(TEST_FILE_1);
 }
 
@@ -624,7 +624,7 @@ TEST_F(ComponentTestInternalParameters, GetError)
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
         m_callbackComplete = true;
     }
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
 }
 
 /**
@@ -645,7 +645,7 @@ TEST_F(ComponentTestInternalParameters, PostError)
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
         m_callbackComplete = true;
     }
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
 }
 
 /**
@@ -666,7 +666,7 @@ TEST_F(ComponentTestInternalParameters, PutError)
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
         m_callbackComplete = true;
     }
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
 }
 
 /**
@@ -686,7 +686,7 @@ TEST_F(ComponentTestInternalParameters, DeleteError)
         EXPECT_EQ(std::string(ex.what()), "HTTP response code said error");
         m_callbackComplete = true;
     }
-    EXPECT_TRUE(m_callbackComplete);
+    EXPECT_FALSE(m_callbackComplete); //We are not longer considering 4xx as errors that throws an exception
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh/issues/32416

# Summary

This change refactors the cURL execution logic to improve error handling and diagnostics. Specifically, it allows the `CurlException` to carry the HTTP response code while preserving the response body for inspection in case of errors.

## Problem Statement

Previously, the cURL handler would **reset the easy handle (`curl_easy_reset`) immediately after an error**, which cleared any buffered response data. This made it impossible to access the server’s response body in failure cases (e.g., 4xx/5xx responses).

Additionally, the use of `OPT_FAILONERROR` caused `curl_easy_perform()` to fail automatically on HTTP errors (≥ 400), without giving us a chance to read the full response.

**Observed behavior:**

* On HTTP 4xx/5xx responses, `curl_easy_perform()` returned `CURLE_HTTP_RETURNED_ERROR`.
* The handle was reset before the exception was thrown.
* The application lost the response body, preventing detailed error reporting or diagnostics.

**Expected behavior:**

* On failure, response data should still be available to the caller.
* The exception should contain the HTTP response code.
* The cURL handle should only be reset after successful execution.

## Solution

The `execute()` method in the cURL handler has been refactored to preserve the response context and provide richer exceptions.

### 1. Defer `curl_easy_reset()`

The reset now occurs **only on success**, ensuring the response data remains accessible when an exception is thrown:

```cpp
// Only reset on success
curl_easy_reset(m_curlHandler.get());
```

### 2. Preserve Response and HTTP Code on Errors

When `CURLE_HTTP_RETURNED_ERROR` occurs, the HTTP response code is retrieved and passed into the `CurlException`, allowing downstream consumers to handle errors based on status code:

```cpp
if (resPerform == CURLE_HTTP_RETURNED_ERROR)
{
    if (resGetInfo != CURLE_OK)
    {
        throw std::runtime_error("cURLSingleHandler::execute() failed: Couldn't get HTTP response code");
    }
    // Throw exception WITHOUT resetting - response data is still available
    throw Curl::CurlException(curl_easy_strerror(resPerform), responseCode);
}
```

### 3. Remove `OPT_FAILONERROR`

The following option is now commented out:

```cpp
// this->setOptionLong(OPT_FAILONERROR, 1l);
```

This prevents automatic failure on HTTP errors, letting the new `execute()` logic handle them manually while still capturing the response body.

## Changes Made

* **`curlSingleHandler.cpp`**

  * Moved `curl_easy_reset()` to only execute on successful requests.
  * Updated exception handling to include response codes and preserve body data.
  * Improved runtime error messages for missing response info.

* **`curlWrapper.hpp`**

  * Updated `CurlException` to accept an optional HTTP response code argument.

* **Removed automatic fail-on-error option (`OPT_FAILONERROR`)** to allow full response capture on server errors.