### PR TITLE
Add payload to delete operation

### DIFF
--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -578,29 +578,93 @@ void HTTPRequest::delete_(std::variant<TRequestParameters<std::string>,
         std::visit(
             [&](auto&& arg)
             {
-                auto req {DeleteRequest::builder(
-                    FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
-                req.url(arg.url.url(), arg.secureCommunication)
-                    .appendHeaders(arg.httpHeaders)
-                    .timeout(timeout)
-                    .userAgent(userAgent)
-                    .outputFile(outputFile)
-                    .execute();
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
+                {
+                    auto req {DeleteRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
+                    req.url(arg.url.url(), arg.secureCommunication)
+                        .template postData<const std::string&>(arg.data)
+                        .appendHeaders(arg.httpHeaders)
+                        .timeout(timeout)
+                        .userAgent(userAgent)
+                        .outputFile(outputFile)
+                        .execute();
 
-                std::visit(
-                    [&](auto&& arg)
-                    {
-                        using Tb = std::decay_t<decltype(arg)>;
-                        if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                    std::visit(
+                        [&](auto&& arg)
                         {
-                            arg.onSuccess(response);
-                        }
-                        else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
+                }
+                else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
+                {
+                    auto req {DeleteRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
+                    req.url(arg.url.url(), arg.secureCommunication)
+                        .template postData<std::string_view>(arg.data)
+                        .appendHeaders(arg.httpHeaders)
+                        .timeout(timeout)
+                        .userAgent(userAgent)
+                        .outputFile(outputFile)
+                        .execute();
+
+                    std::visit(
+                        [&](auto&& arg)
                         {
-                            arg.onSuccess(std::move(response));
-                        }
-                    },
-                    postRequestParameters);
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
+                }
+                else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
+                {
+                    const std::string data = arg.data.dump();
+                    auto req {DeleteRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
+                    req.url(arg.url.url(), arg.secureCommunication)
+                        .template postData<const std::string&>(data)
+                        .appendHeaders(arg.httpHeaders)
+                        .timeout(timeout)
+                        .userAgent(userAgent)
+                        .outputFile(outputFile)
+                        .execute();
+
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
+                }
+                else
+                {
+                    throw std::runtime_error("Invalid type");
+                }
             },
             requestParameters);
     }

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -574,29 +574,93 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
         std::visit(
             [&](auto&& arg)
             {
-                auto req {DeleteRequest::builder(
-                    FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
-                req.url(arg.url.url(), arg.secureCommunication)
-                    .unixSocketPath(arg.url.unixSocketPath())
-                    .timeout(timeout)
-                    .userAgent(userAgent)
-                    .outputFile(outputFile)
-                    .execute();
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, TRequestParameters<std::string>>)
+                {
+                    auto req {DeleteRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
+                    req.url(arg.url.url(), arg.secureCommunication)
+                        .unixSocketPath(arg.url.unixSocketPath())
+                        .timeout(timeout)
+                        .userAgent(userAgent)
+                        .template postData<const std::string&>(arg.data)
+                        .outputFile(outputFile)
+                        .execute();
 
-                std::visit(
-                    [&](auto&& arg)
-                    {
-                        using Tb = std::decay_t<decltype(arg)>;
-                        if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                    std::visit(
+                        [&](auto&& arg)
                         {
-                            arg.onSuccess(response);
-                        }
-                        else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
+                }
+                else if constexpr (std::is_same_v<T, TRequestParameters<std::string_view>>)
+                {
+                    auto req {DeleteRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
+                    req.url(arg.url.url(), arg.secureCommunication)
+                        .unixSocketPath(arg.url.unixSocketPath())
+                        .timeout(timeout)
+                        .userAgent(userAgent)
+                        .template postData<std::string_view>(arg.data)
+                        .outputFile(outputFile)
+                        .execute();
+
+                    std::visit(
+                        [&](auto&& arg)
                         {
-                            arg.onSuccess(std::move(response));
-                        }
-                    },
-                    postRequestParameters);
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
+                }
+                else if constexpr (std::is_same_v<T, TRequestParameters<nlohmann::json>>)
+                {
+                    const auto data = arg.data.dump();
+                    auto req {DeleteRequest::builder(
+                        FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
+                    req.url(arg.url.url(), arg.secureCommunication)
+                        .template postData<const std::string&>(data)
+                        .appendHeaders(arg.httpHeaders)
+                        .timeout(timeout)
+                        .userAgent(userAgent)
+                        .outputFile(outputFile)
+                        .execute();
+
+                    std::visit(
+                        [&](auto&& arg)
+                        {
+                            using Tb = std::decay_t<decltype(arg)>;
+                            if constexpr (std::is_same_v<Tb, TPostRequestParameters<const std::string&>>)
+                            {
+                                arg.onSuccess(response);
+                            }
+                            else if constexpr (std::is_same_v<Tb, TPostRequestParameters<std::string&&>>)
+                            {
+                                arg.onSuccess(std::move(response));
+                            }
+                        },
+                        postRequestParameters);
+                }
+                else
+                {
+                    throw std::runtime_error("Invalid type");
+                }
             },
             requestParameters);
     }

--- a/src/UNIXSocketRequest.cpp
+++ b/src/UNIXSocketRequest.cpp
@@ -42,6 +42,7 @@ void UNIXSocketRequest::download(std::variant<TRequestParameters<std::string>,
                 GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))
                     .url(arg.url.url(), arg.secureCommunication)
                     .unixSocketPath(arg.url.unixSocketPath())
+                    .appendHeaders(arg.httpHeaders)
                     .timeout(timeout)
                     .userAgent(userAgent)
                     .outputFile(outputFile)
@@ -102,6 +103,7 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<const std::string&>(arg.data)
@@ -128,6 +130,7 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<std::string_view>(arg.data)
@@ -156,6 +159,7 @@ void UNIXSocketRequest::post(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<const std::string&>(data)
@@ -234,6 +238,7 @@ void UNIXSocketRequest::get(std::variant<TRequestParameters<std::string>,
                     GetRequest::builder(FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                 req.url(arg.url.url(), arg.secureCommunication)
                     .unixSocketPath(arg.url.unixSocketPath())
+                    .appendHeaders(arg.httpHeaders)
                     .timeout(timeout)
                     .userAgent(userAgent)
                     .outputFile(outputFile)
@@ -309,6 +314,7 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<const std::string&>(arg.data)
@@ -336,6 +342,7 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<std::string_view>(arg.data)
@@ -364,6 +371,7 @@ void UNIXSocketRequest::put(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .template postData<const std::string&>(data)
+                        .unixSocketPath(arg.url.unixSocketPath())
                         .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
@@ -445,6 +453,7 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<const std::string&>(arg.data)
@@ -472,6 +481,7 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<std::string_view>(arg.data)
@@ -500,6 +510,7 @@ void UNIXSocketRequest::patch(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<const std::string&>(data)
@@ -581,6 +592,7 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<const std::string&>(arg.data)
@@ -608,6 +620,7 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
                         .unixSocketPath(arg.url.unixSocketPath())
+                        .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)
                         .userAgent(userAgent)
                         .template postData<std::string_view>(arg.data)
@@ -635,6 +648,7 @@ void UNIXSocketRequest::delete_(std::variant<TRequestParameters<std::string>,
                     auto req {DeleteRequest::builder(
                         FactoryRequestWrapper<wrapperType>::create(response, handlerType, shouldRun))};
                     req.url(arg.url.url(), arg.secureCommunication)
+                        .unixSocketPath(arg.url.unixSocketPath())
                         .template postData<const std::string&>(data)
                         .appendHeaders(arg.httpHeaders)
                         .timeout(timeout)

--- a/src/urlRequest.hpp
+++ b/src/urlRequest.hpp
@@ -436,7 +436,7 @@ public:
 /**
  * @brief This class is a wrapper for curl library. It provides a simple interface to perform HTTP DELETE requests.
  */
-class DeleteRequest final : public cURLRequest<DeleteRequest>
+class DeleteRequest final : public cURLRequest<DeleteRequest>, public PostData<DeleteRequest>
 {
 public:
     /**
@@ -445,6 +445,7 @@ public:
      */
     explicit DeleteRequest(std::shared_ptr<IRequestImplementator> requestImplementator)
         : cURLRequest<DeleteRequest>(requestImplementator)
+        , PostData<DeleteRequest>(requestImplementator)
     {
         requestImplementator->setOptionString(OPT_CUSTOMREQUEST, METHOD_TYPE_MAP.at(METHOD_DELETE));
     }

--- a/test/component/component_test.cpp
+++ b/test/component/component_test.cpp
@@ -1619,3 +1619,107 @@ TEST_F(ComponentTestInterface, Post100MbsStringView)
 
     EXPECT_LE(postPost, prePost + SERVER_RSS_USAGE);
 }
+
+/**
+ * @brief Test the delete request sending a JSON payload.
+ */
+TEST_F(ComponentTestInterface, DeleteHelloWorldWithPayloadJson)
+{
+    bool errorOccurred = false;
+
+    HTTPRequest::instance().delete_(
+        RequestParametersJson {.url = HttpURL("http://localhost:44441/"), .data = R"({"hello":"world"})"_json},
+        PostRequestParameters {.onSuccess =
+                                   [&](const std::string& result)
+                               {
+                                   EXPECT_EQ(result, R"({"hello":"world"})");
+                                   m_callbackComplete = true;
+                               },
+                               .onError =
+                                   [&](const std::string& error, const long, const std::string&)
+                               {
+                                   errorOccurred = true;
+                                   GTEST_SKIP() << "Test server not available on localhost:44441 - " << error;
+                               }});
+
+    if (!errorOccurred)
+    {
+        EXPECT_TRUE(m_callbackComplete);
+    }
+    else
+    {
+        SUCCEED();
+    }
+}
+
+/**
+ * @brief Test the delete request sending a raw payload (echo body).
+ */
+TEST_F(ComponentTestInterface, DeleteHelloWorldWithPayloadRaw)
+{
+    bool errorOccurred = false;
+
+    HTTPRequest::instance().delete_(
+        RequestParameters {.url = HttpURL("http://localhost:44441/"), .data = "hello world"},
+        PostRequestParameters {.onSuccess =
+                                   [&](const std::string& result)
+                               {
+                                   EXPECT_EQ(result, "hello world");
+                                   m_callbackComplete = true;
+                               },
+                               .onError =
+                                   [&](const std::string& error, const long, const std::string&)
+                               {
+                                   errorOccurred = true;
+                                   GTEST_SKIP() << "Test server not available on localhost:44441 - " << error;
+                               }});
+
+    if (!errorOccurred)
+    {
+        EXPECT_TRUE(m_callbackComplete);
+    }
+    else
+    {
+        SUCCEED();
+    }
+}
+
+/**
+ * @brief Test the DELETE request appending a custom header and sending payload.
+ */
+TEST_F(ComponentTestInterface, DeleteWithCustomHeaderAndPayload)
+{
+    const std::string headerKey {"Custom-Key"};
+    const std::string headerValue {"Custom-Value"};
+    bool errorOccurred = false;
+
+    HTTPRequest::instance().delete_(
+        RequestParametersJson {.url = HttpURL("http://localhost:44441/check-headers-and-body"),
+                               .data = R"({"hello":"world"})"_json,
+                               .httpHeaders = {headerKey + ":" + headerValue}},
+        PostRequestParameters {.onSuccess =
+                                   [&](const std::string& result)
+                               {
+                                   const auto response = nlohmann::json::parse(result);
+
+                                   ASSERT_EQ(response.at("headers").at(headerKey), headerValue);
+                                   ASSERT_EQ(response.at("body"), R"({"hello":"world"})");
+
+                                   m_callbackComplete = true;
+                               },
+                               .onError =
+                                   [&](const std::string& error, const long, const std::string&)
+                               {
+                                   errorOccurred = true;
+                                   GTEST_SKIP() << "Test server not available on localhost:44441 - " << error;
+                               }});
+
+    if (!errorOccurred)
+    {
+        EXPECT_TRUE(m_callbackComplete);
+    }
+    else
+    {
+        SUCCEED();
+    }
+}

--- a/test/component/component_test.hpp
+++ b/test/component/component_test.hpp
@@ -236,6 +236,19 @@ private:
                       [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
                       { res.set_content(getHttpHeaders(req).dump(), "text/json"); });
 
+        server.Delete("/check-headers-and-body",
+            [&getHttpHeaders](const httplib::Request& req, httplib::Response& res)
+            {
+                nlohmann::json out;
+                out["headers"] = getHttpHeaders(req);
+                out["body"] = req.body;
+                res.set_content(out.dump(), "text/json");
+            });
+
+        server.Delete("/",
+              [](const httplib::Request& req, httplib::Response& res)
+              { res.set_content(req.body, "text/json"); });
+
         server.set_keep_alive_max_count(1);
         server.listen("localhost", 44441);
     }

--- a/test/unit/unit_test.cpp
+++ b/test/unit/unit_test.cpp
@@ -299,6 +299,74 @@ TEST_F(UrlRequestUnitTest, DeleteApiRequest)
 }
 
 /**
+ * @brief This test checks the API DELETE request with post field.
+ */
+TEST_F(UrlRequestUnitTest, DeleteApiRequestWithPostFields)
+{
+    auto request {std::make_shared<RequestWrapper>()};
+
+    constexpr auto payload = R"({"id":"123"})";
+
+    EXPECT_CALL(*request, setOptionString(optUrl, "http://www.wazuh.com/")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optCustomRequest, "DELETE")).Times(1);
+    EXPECT_CALL(*request, appendHeader("Content-Type: Application/json")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optUserAgent, "Wazuh-Agent/1.0")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optCainfo, "cert.ca")).Times(1);
+    EXPECT_CALL(*request, setOptionLong(optTimeout, 10)).Times(1);
+
+    // Payload
+    EXPECT_CALL(*request, setOptionString(optPostFields, payload)).Times(1);
+    EXPECT_CALL(*request, setOptionLong(optPostFieldSize, std::string(payload).length())).Times(1);
+
+    EXPECT_CALL(*request, setOptionLong(optVerifyPeer, 1L)).Times(1);
+    EXPECT_CALL(*request, execute()).Times(1);
+
+    DeleteRequest::builder(request)
+        .url("http://www.wazuh.com/")
+        .appendHeader("Content-Type: Application/json")
+        .userAgent("Wazuh-Agent/1.0")
+        .certificate("cert.ca")
+        .timeout(10)
+        .template postData<std::string>(payload)
+        .execute();
+}
+
+/**
+ * @brief This test checks the API DELETE request with post field and unix socket.
+ */
+TEST_F(UrlRequestUnitTest, DeleteApiRequestWithPostFieldsAndUnixSocket)
+{
+    auto request {std::make_shared<RequestWrapper>()};
+
+    constexpr auto payload = R"({"id":"123"})";
+
+    EXPECT_CALL(*request, setOptionString(optUnixSocketPath, "/tmp/wazuh-agent.sock")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optUrl, "http://www.wazuh.com/")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optCustomRequest, "DELETE")).Times(1);
+    EXPECT_CALL(*request, appendHeader("Content-Type: Application/json")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optUserAgent, "Wazuh-Agent/1.0")).Times(1);
+    EXPECT_CALL(*request, setOptionString(optCainfo, "cert.ca")).Times(1);
+    EXPECT_CALL(*request, setOptionLong(optTimeout, 10)).Times(1);
+
+    // Payload
+    EXPECT_CALL(*request, setOptionString(optPostFields, payload)).Times(1);
+    EXPECT_CALL(*request, setOptionLong(optPostFieldSize, std::string(payload).length())).Times(1);
+
+    EXPECT_CALL(*request, setOptionLong(optVerifyPeer, 1L)).Times(1);
+    EXPECT_CALL(*request, execute()).Times(1);
+
+    DeleteRequest::builder(request)
+        .url("http://www.wazuh.com/")
+        .appendHeader("Content-Type: Application/json")
+        .userAgent("Wazuh-Agent/1.0")
+        .certificate("cert.ca")
+        .timeout(10)
+        .template postData<std::string>(payload)
+        .unixSocketPath("/tmp/wazuh-agent.sock")
+        .execute();
+}
+
+/**
  * @brief This test checks the malformed API DELETE request.
  */
 TEST_F(UrlRequestUnitTest, BadConstructorDelete)

--- a/test_tool/actions.hpp
+++ b/test_tool/actions.hpp
@@ -227,7 +227,7 @@ public:
     void execute() override
     {
         HTTPRequest::instance().put(
-            RequestParameters {.url = HttpURL(m_url),
+            TRequestParameters<nlohmann::json> {.url = HttpURL(m_url),
                                .data = m_data,
                                .secureCommunication = m_secureCommunication,
                                .httpHeaders = m_headers},
@@ -286,7 +286,7 @@ public:
     void execute() override
     {
         HTTPRequest::instance().patch(
-            RequestParameters {.url = HttpURL(m_url),
+            TRequestParameters<nlohmann::json> {.url = HttpURL(m_url),
                                .data = m_data,
                                .secureCommunication = m_secureCommunication,
                                .httpHeaders = m_headers},
@@ -309,6 +309,7 @@ class DeleteAction final : public IAction
 {
 private:
     std::string m_url;
+    nlohmann::json m_data;
     std::unordered_set<std::string> m_headers;
     SecureCommunication m_secureCommunication;
     long m_timeout;
@@ -322,10 +323,12 @@ public:
      * @param timeout Timeout for the request.
      */
     explicit DeleteAction(const std::string& url,
+                          const nlohmann::json& data,
                           const std::unordered_set<std::string>& headers,
                           const SecureCommunication& secureCommunication,
                           const long timeout)
         : m_url(url)
+        , m_data(data)
         , m_headers(headers)
         , m_secureCommunication(secureCommunication)
         , m_timeout(timeout)
@@ -338,17 +341,21 @@ public:
     void execute() override
     {
         HTTPRequest::instance().delete_(
-            RequestParameters {
-                .url = HttpURL(m_url), .secureCommunication = m_secureCommunication, .httpHeaders = m_headers},
-            PostRequestParameters {
+            TRequestParameters<nlohmann::json> {
+                .url = HttpURL(m_url),
+                .data = m_data,
+                .secureCommunication = m_secureCommunication,
+                .httpHeaders = m_headers
+            },
+            PostRequestParameters{
                 .onSuccess = [](const std::string& msg) { std::cout << msg << std::endl; },
-                .onError =
-                    [](const std::string& msg, const long responseCode, const std::string& responseBody)
+                .onError = [](const std::string& msg, const long code, const std::string& body)
                 {
-                    std::cerr << msg << ": " << responseCode << ". Response body: " << responseBody << std::endl;
+                    std::cerr << msg << ": " << code << ". Response body: " << body << std::endl;
                     throw std::runtime_error(msg);
-                }},
-            ConfigurationParameters {.timeout = m_timeout});
+                }
+            },
+            ConfigurationParameters{.timeout = m_timeout});
     }
 };
 

--- a/test_tool/factoryAction.hpp
+++ b/test_tool/factoryAction.hpp
@@ -78,7 +78,8 @@ public:
         }
         else if (0 == args.type().compare("delete"))
         {
-            return std::make_unique<DeleteAction>(args.url(), headers, secureCommunication, timeout);
+            return std::make_unique<DeleteAction>(
+                args.url(), args.postArguments(), headers, secureCommunication, timeout);
         }
         else
         {


### PR DESCRIPTION
## Description

This pull request adds support for **sending a payload in DELETE requests** in the **urlRequest TestTool**.

Previously, DELETE actions did not reliably support request bodies, and providing a JSON payload could lead to runtime errors due to implicit type conversions. With this change, DELETE requests now handle payloads consistently with other HTTP methods such as POST, PUT, and PATCH.

---

## Proposed Changes

- Added support for **JSON payloads in DELETE requests**.
- Explicitly use `TRequestParameters<nlohmann::json>` for DELETE actions to avoid implicit `json → std::string` conversions.
- Ensure JSON payloads are correctly serialized before being sent.
- Align DELETE request behavior with POST/PUT/PATCH for more consistent API testing.

---

## Motivation

Some REST APIs allow or require a request body in DELETE operations (for example, to specify resources, filters, or conditions). Without payload support, the TestTool could not accurately test these APIs.

This change improves flexibility and correctness when testing REST endpoints that expect a DELETE body.

---

## Testing

<details>

```
import base64
import json
from http.server import BaseHTTPRequestHandler, HTTPServer
from urllib.parse import urlparse, parse_qs
import argparse

STORE = {}

class Handler(BaseHTTPRequestHandler):
    server_version = "MiniRestServer/1.0"

    def _json(self, code: int, payload: dict):
        self.send_response(code)
        self.send_header("Content-Type", "application/json")
        self.end_headers()
        self.wfile.write(json.dumps(payload, ensure_ascii=False).encode("utf-8"))

    def _unauthorized(self):
        self.send_response(401)
        self.send_header("Content-Type", "application/json")
        self.send_header("WWW-Authenticate", 'Basic realm="test"')
        self.end_headers()
        self.wfile.write(json.dumps({"status": "error", "error": "unauthorized"}).encode("utf-8"))

    def _check_basic_auth(self) -> bool:
        user = getattr(self.server, "auth_user", None)
        pwd = getattr(self.server, "auth_pass", None)
        if not user:
            return True

        auth = self.headers.get("Authorization", "")
        if not auth.startswith("Basic "):
            return False
        try:
            decoded = base64.b64decode(auth.split(" ", 1)[1]).decode("utf-8")
        except Exception:
            return False
        return decoded == f"{user}:{pwd}"

    def _read_body(self):
        length = int(self.headers.get("Content-Length", "0"))
        if length <= 0:
            return None, ""
        raw = self.rfile.read(length)
        text = raw.decode("utf-8", errors="replace").strip()
        if not text:
            return None, ""
        try:
            return json.loads(text), text
        except json.JSONDecodeError:
            return text, text

    def _get_id(self, parsed, body_obj):
        qs = parse_qs(parsed.query)
        if "id" in qs and qs["id"]:
            return qs["id"][0]
        if isinstance(body_obj, dict) and "id" in body_obj:
            return str(body_obj["id"])
        return None

    def do_GET(self):
        if not self._check_basic_auth():
            return self._unauthorized()

        parsed = urlparse(self.path)
        if parsed.path != "/resource":
            return self._json(404, {"status": "error", "error": "not_found"})

        qs = parse_qs(parsed.query)
        rid = qs.get("id", [None])[0]
        if rid:
            if rid not in STORE:
                return self._json(404, {"status": "error", "error": "not_found", "id": rid})
            return self._json(200, {"status": "ok", "data": STORE[rid]})

        return self._json(200, {"status": "ok", "data": list(STORE.values())})

    def do_PUT(self):
        if not self._check_basic_auth():
            return self._unauthorized()

        parsed = urlparse(self.path)
        if parsed.path != "/resource":
            return self._json(404, {"status": "error", "error": "not_found"})

        body_obj, body_raw = self._read_body()
        if not isinstance(body_obj, dict):
            return self._json(400, {"status": "error", "error": "body_must_be_json_object", "body_raw": body_raw})

        rid = self._get_id(parsed, body_obj)
        if not rid:
            return self._json(400, {"status": "error", "error": "missing_id"})

        new_obj = dict(body_obj)
        new_obj["id"] = rid

        existed = rid in STORE
        STORE[rid] = new_obj

        return self._json(
            200,
            {
                "status": "ok",
                "action": "replaced" if existed else "created",
                "data": new_obj,
            },
        )

    def do_DELETE(self):
        if not self._check_basic_auth():
            return self._unauthorized()

        parsed = urlparse(self.path)
        if parsed.path != "/resource":
            return self._json(404, {"status": "error", "error": "not_found"})

        body_obj, _ = self._read_body()
        rid = self._get_id(parsed, body_obj)
        if not rid:
            return self._json(400, {"status": "error", "error": "missing_id"})

        if rid not in STORE:
            return self._json(404, {"status": "error", "error": "not_found", "id": rid})

        deleted = STORE.pop(rid)
        return self._json(200, {"status": "ok", "deleted": deleted})

    def log_message(self, fmt, *args):
        pass

def main():
    ap = argparse.ArgumentParser()
    ap.add_argument("--host", default="127.0.0.1")
    ap.add_argument("--port", type=int, default=8000)
    ap.add_argument("--user", default=None)
    ap.add_argument("--pass", dest="pwd", default=None)
    args = ap.parse_args()

    httpd = HTTPServer((args.host, args.port), Handler)
    httpd.auth_user = args.user
    httpd.auth_pass = args.pwd

    print(f"Listening on http://{args.host}:{args.port}")
    if args.user:
        print("Basic auth enabled")
    httpd.serve_forever()

if __name__ == "__main__":
    main()
```

</details>

```
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test_tool/urlrequest_testtool -u http://127.0.0.1:8000/resource -t put -p del.json                                                   1 ↵
{"status": "ok", "action": "replaced", "data": {"id": "123"}}
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test_tool/urlrequest_testtool -u http://127.0.0.1:8000/resource -t get               
{"status": "ok", "data": [{"id": "123"}]}
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test_tool/urlrequest_testtool -u http://127.0.0.1:8000/resource -t delete -p del.json
{"status": "ok", "deleted": {"id": "123"}}
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test_tool/urlrequest_testtool -u http://127.0.0.1:8000/resource -t put -p del.json   
{"status": "ok", "action": "created", "data": {"id": "123"}}
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test_tool/urlrequest_testtool -u http://127.0.0.1:8000/resource -t get               
{"status": "ok", "data": [{"id": "123"}]}
(venv) ╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test_tool/urlrequest_testtool -u http://127.0.0.1:8000/resource -t delete -p del.json
Client error: 404. Response body: {"status": "error", "error": "not_found", "id": "12"}


╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test/component/urlrequest_component_test
[==========] Running 67 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 55 tests from ComponentTestInterface
[ RUN      ] ComponentTestInterface.GetHelloWorld
[       OK ] ComponentTestInterface.GetHelloWorld (34 ms)
[ RUN      ] ComponentTestInterface.GetHelloWorldRedirection
[       OK ] ComponentTestInterface.GetHelloWorldRedirection (14 ms)
[ RUN      ] ComponentTestInterface.PostHelloWorld
[       OK ] ComponentTestInterface.PostHelloWorld (17 ms)
[ RUN      ] ComponentTestInterface.PutHelloWorld
[       OK ] ComponentTestInterface.PutHelloWorld (29 ms)
[ RUN      ] ComponentTestInterface.DeleteRandomID
[       OK ] ComponentTestInterface.DeleteRandomID (25 ms)
[ RUN      ] ComponentTestInterface.DownloadFile
[       OK ] ComponentTestInterface.DownloadFile (20 ms)
[ RUN      ] ComponentTestInterface.DownloadFileEmptyURL
[       OK ] ComponentTestInterface.DownloadFileEmptyURL (16 ms)
[ RUN      ] ComponentTestInterface.DownloadFileError
[       OK ] ComponentTestInterface.DownloadFileError (29 ms)
[ RUN      ] ComponentTestInterface.DownloadFileUsingTheSingleHandler
[       OK ] ComponentTestInterface.DownloadFileUsingTheSingleHandler (17 ms)
[ RUN      ] ComponentTestInterface.DownloadFileEmptyURLUsingTheSingleHandler
[       OK ] ComponentTestInterface.DownloadFileEmptyURLUsingTheSingleHandler (22 ms)
[ RUN      ] ComponentTestInterface.DownloadFileErrorUsingTheSingleHandler
[       OK ] ComponentTestInterface.DownloadFileErrorUsingTheSingleHandler (23 ms)
[ RUN      ] ComponentTestInterface.DownloadFileUsingTheMultiHandler
[       OK ] ComponentTestInterface.DownloadFileUsingTheMultiHandler (30 ms)
[ RUN      ] ComponentTestInterface.InterruptMultiHandler
[       OK ] ComponentTestInterface.InterruptMultiHandler (17 ms)
[ RUN      ] ComponentTestInterface.InterruptDownload
[       OK ] ComponentTestInterface.InterruptDownload (63 ms)
[ RUN      ] ComponentTestInterface.DownloadFileEmptyURLUsingTheMultiHandler
[       OK ] ComponentTestInterface.DownloadFileEmptyURLUsingTheMultiHandler (12 ms)
[ RUN      ] ComponentTestInterface.DownloadFileErrorUsingTheMultiHandler
[       OK ] ComponentTestInterface.DownloadFileErrorUsingTheMultiHandler (29 ms)
[ RUN      ] ComponentTestInterface.GetHelloWorldFile
[       OK ] ComponentTestInterface.GetHelloWorldFile (24 ms)
[ RUN      ] ComponentTestInterface.GetHelloWorldFileJson
[       OK ] ComponentTestInterface.GetHelloWorldFileJson (46 ms)
[ RUN      ] ComponentTestInterface.GetHelloWorldFileEmptyURL
[       OK ] ComponentTestInterface.GetHelloWorldFileEmptyURL (17 ms)
[ RUN      ] ComponentTestInterface.PostHelloWorldFile

[       OK ] ComponentTestInterface.PostHelloWorldFile (42 ms)
[ RUN      ] ComponentTestInterface.PostHelloWorldFileRaw

[       OK ] ComponentTestInterface.PostHelloWorldFileRaw (28 ms)
[ RUN      ] ComponentTestInterface.PostHelloWorldFileEmptyURL
[       OK ] ComponentTestInterface.PostHelloWorldFileEmptyURL (26 ms)
[ RUN      ] ComponentTestInterface.PutHelloWorldFile

[       OK ] ComponentTestInterface.PutHelloWorldFile (32 ms)
[ RUN      ] ComponentTestInterface.PutHelloWorldFileRaw

[       OK ] ComponentTestInterface.PutHelloWorldFileRaw (40 ms)
[ RUN      ] ComponentTestInterface.PutHelloWorldFileEmptyURL
[       OK ] ComponentTestInterface.PutHelloWorldFileEmptyURL (14 ms)
[ RUN      ] ComponentTestInterface.DeleteRandomIDFile

[       OK ] ComponentTestInterface.DeleteRandomIDFile (31 ms)
[ RUN      ] ComponentTestInterface.DeleteRandomIDFileEmptyURL
[       OK ] ComponentTestInterface.DeleteRandomIDFileEmptyURL (14 ms)
[ RUN      ] ComponentTestInterface.GetWithCustomHeader
[       OK ] ComponentTestInterface.GetWithCustomHeader (50 ms)
[ RUN      ] ComponentTestInterface.GetWithDefaultHeaders
[       OK ] ComponentTestInterface.GetWithDefaultHeaders (37 ms)
[ RUN      ] ComponentTestInterface.PostWithCustomHeaders
[       OK ] ComponentTestInterface.PostWithCustomHeaders (34 ms)
[ RUN      ] ComponentTestInterface.PutWithCustomHeaders
[       OK ] ComponentTestInterface.PutWithCustomHeaders (24 ms)
[ RUN      ] ComponentTestInterface.PatchSimpleFunctionality
[       OK ] ComponentTestInterface.PatchSimpleFunctionality (27 ms)
[ RUN      ] ComponentTestInterface.DownloadWithCustomUserAgent
[       OK ] ComponentTestInterface.DownloadWithCustomUserAgent (33 ms)
[ RUN      ] ComponentTestInterface.PostWithCustomUserAgent
[       OK ] ComponentTestInterface.PostWithCustomUserAgent (20 ms)
[ RUN      ] ComponentTestInterface.GetWithCustomUserAgent
[       OK ] ComponentTestInterface.GetWithCustomUserAgent (53 ms)
[ RUN      ] ComponentTestInterface.PutWithCustomUserAgent
[       OK ] ComponentTestInterface.PutWithCustomUserAgent (53 ms)
[ RUN      ] ComponentTestInterface.PatchWithCustomUserAgent
[       OK ] ComponentTestInterface.PatchWithCustomUserAgent (37 ms)
[ RUN      ] ComponentTestInterface.DeleteWithCustomUserAgent
[       OK ] ComponentTestInterface.DeleteWithCustomUserAgent (30 ms)
[ RUN      ] ComponentTestInterface.DownloadTestTimeoutSingleHandler
[       OK ] ComponentTestInterface.DownloadTestTimeoutSingleHandler (66 ms)
[ RUN      ] ComponentTestInterface.DownloadTestTimeoutMultiHandler
[       OK ] ComponentTestInterface.DownloadTestTimeoutMultiHandler (43 ms)
[ RUN      ] ComponentTestInterface.GetTestTimeoutSingleHandler
[       OK ] ComponentTestInterface.GetTestTimeoutSingleHandler (43 ms)
[ RUN      ] ComponentTestInterface.GetTestTimeoutMultiHandler
[       OK ] ComponentTestInterface.GetTestTimeoutMultiHandler (41 ms)
[ RUN      ] ComponentTestInterface.PutTestTimeoutSingleHandler
[       OK ] ComponentTestInterface.PutTestTimeoutSingleHandler (48 ms)
[ RUN      ] ComponentTestInterface.PutTestTimeoutMultiHandler
[       OK ] ComponentTestInterface.PutTestTimeoutMultiHandler (29 ms)
[ RUN      ] ComponentTestInterface.PatchTestTimeoutSingleHandler
[       OK ] ComponentTestInterface.PatchTestTimeoutSingleHandler (49 ms)
[ RUN      ] ComponentTestInterface.PatchTestTimeoutMultiHandler
[       OK ] ComponentTestInterface.PatchTestTimeoutMultiHandler (52 ms)
[ RUN      ] ComponentTestInterface.DeleteTestTimeoutSingleHandler
[       OK ] ComponentTestInterface.DeleteTestTimeoutSingleHandler (57 ms)
[ RUN      ] ComponentTestInterface.DeleteTestTimeoutMultiHandler
[       OK ] ComponentTestInterface.DeleteTestTimeoutMultiHandler (42 ms)
[ RUN      ] ComponentTestInterface.PostTestTimeoutSingleHandler
[       OK ] ComponentTestInterface.PostTestTimeoutSingleHandler (46 ms)
[ RUN      ] ComponentTestInterface.PostTestTimeoutMultiHandler
[       OK ] ComponentTestInterface.PostTestTimeoutMultiHandler (58 ms)
[ RUN      ] ComponentTestInterface.Post100Mbs
[       OK ] ComponentTestInterface.Post100Mbs (964 ms)
[ RUN      ] ComponentTestInterface.Post100MbsStringView
[       OK ] ComponentTestInterface.Post100MbsStringView (775 ms)
[ RUN      ] ComponentTestInterface.DeleteHelloWorldWithPayloadJson
[       OK ] ComponentTestInterface.DeleteHelloWorldWithPayloadJson (14 ms)
[ RUN      ] ComponentTestInterface.DeleteHelloWorldWithPayloadRaw
[       OK ] ComponentTestInterface.DeleteHelloWorldWithPayloadRaw (24 ms)
[ RUN      ] ComponentTestInterface.DeleteWithCustomHeaderAndPayload
[       OK ] ComponentTestInterface.DeleteWithCustomHeaderAndPayload (38 ms)
[----------] 55 tests from ComponentTestInterface (3551 ms total)

[----------] 12 tests from ComponentTestInternalParameters
[ RUN      ] ComponentTestInternalParameters.DownloadFileEmptyInvalidUrl
[       OK ] ComponentTestInternalParameters.DownloadFileEmptyInvalidUrl (23 ms)
[ RUN      ] ComponentTestInternalParameters.DownloadFileEmptyInvalidUrl2
[       OK ] ComponentTestInternalParameters.DownloadFileEmptyInvalidUrl2 (26 ms)
[ RUN      ] ComponentTestInternalParameters.GetError
[       OK ] ComponentTestInternalParameters.GetError (44 ms)
[ RUN      ] ComponentTestInternalParameters.PostError
[       OK ] ComponentTestInternalParameters.PostError (47 ms)
[ RUN      ] ComponentTestInternalParameters.PutError
[       OK ] ComponentTestInternalParameters.PutError (37 ms)
[ RUN      ] ComponentTestInternalParameters.DeleteError
[       OK ] ComponentTestInternalParameters.DeleteError (44 ms)
[ RUN      ] ComponentTestInternalParameters.ExecuteGetNoUrl
[       OK ] ComponentTestInternalParameters.ExecuteGetNoUrl (29 ms)
[ RUN      ] ComponentTestInternalParameters.ExecutePostNoUrl
[       OK ] ComponentTestInternalParameters.ExecutePostNoUrl (45 ms)
[ RUN      ] ComponentTestInternalParameters.ExecutePutNoUrl
[       OK ] ComponentTestInternalParameters.ExecutePutNoUrl (63 ms)
[ RUN      ] ComponentTestInternalParameters.ExecuteDeleteNoUrl
[       OK ] ComponentTestInternalParameters.ExecuteDeleteNoUrl (42 ms)
[ RUN      ] ComponentTestInternalParameters.MultipleThreads
[       OK ] ComponentTestInternalParameters.MultipleThreads (2064 ms)
[ RUN      ] ComponentTestInternalParameters.MultipleThreadsWithMultiHandlers
[       OK ] ComponentTestInternalParameters.MultipleThreadsWithMultiHandlers (2136 ms)
[----------] 12 tests from ComponentTestInternalParameters (4611 ms total)

[----------] Global test environment tear-down
[==========] 67 tests from 2 test suites ran. (8163 ms total)
[  PASSED  ] 67 tests.

╭─root@ca37659e68c4 /workspaces/devContainer/wazuh-http-request/build ‹bug/77-delete-requests-do-not-send-payload●› 
╰─# ./test/unit/urlrequest_unit_test          
[==========] Running 31 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 7 tests from cURLHandlerCacheTest
[ RUN      ] cURLHandlerCacheTest.SingleHandlerCreation
[       OK ] cURLHandlerCacheTest.SingleHandlerCreation (1 ms)
[ RUN      ] cURLHandlerCacheTest.MultiHandlerCreation
[       OK ] cURLHandlerCacheTest.MultiHandlerCreation (0 ms)
[ RUN      ] cURLHandlerCacheTest.SingleHandlerInMultipleThreads
[       OK ] cURLHandlerCacheTest.SingleHandlerInMultipleThreads (3 ms)
[ RUN      ] cURLHandlerCacheTest.MultiHandlerInMultipleThreads
[       OK ] cURLHandlerCacheTest.MultiHandlerInMultipleThreads (15 ms)
[ RUN      ] cURLHandlerCacheTest.SingleHandlerAndMultiHandlerInTheSameThread
[       OK ] cURLHandlerCacheTest.SingleHandlerAndMultiHandlerInTheSameThread (2 ms)
[ RUN      ] cURLHandlerCacheTest.TwoSingleHandlerInTheSameThread
[       OK ] cURLHandlerCacheTest.TwoSingleHandlerInTheSameThread (0 ms)
[ RUN      ] cURLHandlerCacheTest.TwoMultiHandlerInTheSameThread
[       OK ] cURLHandlerCacheTest.TwoMultiHandlerInTheSameThread (0 ms)
[----------] 7 tests from cURLHandlerCacheTest (25 ms total)

[----------] 4 tests from SecureCommunicationTest
[ RUN      ] SecureCommunicationTest.CACertificate
[       OK ] SecureCommunicationTest.CACertificate (0 ms)
[ RUN      ] SecureCommunicationTest.BasicAuth
[       OK ] SecureCommunicationTest.BasicAuth (0 ms)
[ RUN      ] SecureCommunicationTest.ClientAuthentication
[       OK ] SecureCommunicationTest.ClientAuthentication (0 ms)
[ RUN      ] SecureCommunicationTest.BasicAndClientAuth
[       OK ] SecureCommunicationTest.BasicAndClientAuth (0 ms)
[----------] 4 tests from SecureCommunicationTest (0 ms total)

[----------] 20 tests from UrlRequestUnitTest
[ RUN      ] UrlRequestUnitTest.GetFileHttp
[       OK ] UrlRequestUnitTest.GetFileHttp (8 ms)
[ RUN      ] UrlRequestUnitTest.HttpSecureConnection
[       OK ] UrlRequestUnitTest.HttpSecureConnection (4 ms)
[ RUN      ] UrlRequestUnitTest.HttpSecureConnectionBasicAuth
[       OK ] UrlRequestUnitTest.HttpSecureConnectionBasicAuth (1 ms)
[ RUN      ] UrlRequestUnitTest.HttpSecureConnectionClientAuth
[       OK ] UrlRequestUnitTest.HttpSecureConnectionClientAuth (2 ms)
[ RUN      ] UrlRequestUnitTest.HttpSecureConnectionBasicAndClientAuth
[       OK ] UrlRequestUnitTest.HttpSecureConnectionBasicAndClientAuth (2 ms)
[ RUN      ] UrlRequestUnitTest.GetFileWithUnixSocket
[       OK ] UrlRequestUnitTest.GetFileWithUnixSocket (1 ms)
[ RUN      ] UrlRequestUnitTest.GetApiRequest
[       OK ] UrlRequestUnitTest.GetApiRequest (1 ms)
[ RUN      ] UrlRequestUnitTest.PostApiRequest
[       OK ] UrlRequestUnitTest.PostApiRequest (1 ms)
[ RUN      ] UrlRequestUnitTest.PostApiRequestWithPostFields
[       OK ] UrlRequestUnitTest.PostApiRequestWithPostFields (1 ms)
[ RUN      ] UrlRequestUnitTest.PostApiRequestWithPostFieldsAndUnixSocket
[       OK ] UrlRequestUnitTest.PostApiRequestWithPostFieldsAndUnixSocket (1 ms)
[ RUN      ] UrlRequestUnitTest.PutApiRequest
[       OK ] UrlRequestUnitTest.PutApiRequest (1 ms)
[ RUN      ] UrlRequestUnitTest.DeleteApiRequest
[       OK ] UrlRequestUnitTest.DeleteApiRequest (1 ms)
[ RUN      ] UrlRequestUnitTest.DeleteApiRequestWithPostFields
[       OK ] UrlRequestUnitTest.DeleteApiRequestWithPostFields (3 ms)
[ RUN      ] UrlRequestUnitTest.DeleteApiRequestWithPostFieldsAndUnixSocket
[       OK ] UrlRequestUnitTest.DeleteApiRequestWithPostFieldsAndUnixSocket (3 ms)
[ RUN      ] UrlRequestUnitTest.BadConstructorDelete
[       OK ] UrlRequestUnitTest.BadConstructorDelete (0 ms)
[ RUN      ] UrlRequestUnitTest.BadConstructorGet
[       OK ] UrlRequestUnitTest.BadConstructorGet (0 ms)
[ RUN      ] UrlRequestUnitTest.BadConstructorPost
[       OK ] UrlRequestUnitTest.BadConstructorPost (0 ms)
[ RUN      ] UrlRequestUnitTest.BadConstructorPut
[       OK ] UrlRequestUnitTest.BadConstructorPut (0 ms)
[ RUN      ] UrlRequestUnitTest.HttpsCertExists
[       OK ] UrlRequestUnitTest.HttpsCertExists (4 ms)
[ RUN      ] UrlRequestUnitTest.HttpsNoCertNotExists
[       OK ] UrlRequestUnitTest.HttpsNoCertNotExists (1 ms)
[----------] 20 tests from UrlRequestUnitTest (45 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 3 test suites ran. (72 ms total)
[  PASSED  ] 31 tests.
```