### PR TITLE
Fix dangling reference outputFile var

### DIFF
--- a/include/IURLRequest.hpp
+++ b/include/IURLRequest.hpp
@@ -218,7 +218,7 @@ struct TPostRequestParameters
      * @brief File name of to store the output data.
      *
      */
-    const std::string& outputFile = "";
+    std::string outputFile {};
 };
 using PostRequestParameters = TPostRequestParameters<>;
 using PostRequestParametersRValue = TPostRequestParameters<std::string&&>;


### PR DESCRIPTION
# Description 

https://github.com/wazuh/wazuh/issues/34611 

```console
2026/02/23 11:14:17 wazuh-manager-modulesd:vulnerability-scanner[70765] eventSendReport.hpp:253 at operator()(): WARNING: EventSendReport - Engine POST failed (exception): std::bad_alloc
```

Debugging this behavior it was found that the outputFile variable during post operation on UNIX sockets has an invalid reference. 

Variable inspection before the change
```console
(gdb) p arg.outputFile
$1 = (const std::string &) @0x7fffdddf19b0: {static npos = 18446744073709551615,
  _M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>},
    _M_p = 0x7fffdddf1f70 "\220\270F\362\377\177"}, _M_string_length = 140736915774016, {
    _M_local_buf = "@\033\337\335\377\177\000\000P\036\337\335\377\177\000", _M_allocated_capacity = 140736915774272}}
```

Variable inspection after the change 
```console
(gdb) p arg.outputFile 
$1 = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = 
  {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>}, 
  _M_p = 0x7fffdafe1c40 ""}, _M_string_length = 0, {_M_local_buf = "\000\000\000\000\000\000\000\000P\037\376\332\377\177\000", _M_allocated_capacity = 0}} (gdb)
```

> [!NOTE]
> We can see the string length value is zero now. 